### PR TITLE
Improve navigation color contrast

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/static/styles.css">
 </head>
 
-<body class="min-h-screen bg-gray-100 font-sans">
+<body class="min-h-screen bg-gradient-to-br from-gray-100 to-gray-200 font-sans">
   {# ------------------------------------------------------------- #
      expect three template variables to be present:
 
@@ -18,44 +18,44 @@
 
      (pass  user=current_user  whenever you call TemplateResponse)
   # ------------------------------------------------------------- #}
-  <header class="fixed top-0 inset-x-0 h-14 bg-gradient-to-r from-blue-800 to-blue-500 shadow flex items-center justify-between px-6 text-white">
+  <header class="fixed top-0 inset-x-0 h-14 bg-gradient-to-r from-blue-900 to-blue-700 shadow flex items-center justify-between px-6 text-white">
     <span class="font-semibold">Recruitment Assistant</span>
 
     <nav class="space-x-6 text-sm">
       {# regular links #}
       <a href="/"
          class="{{ 'text-white font-semibold' if active=='/' else
-                  'text-blue-100 hover:text-white' }}">Home</a>
+                  'text-blue-200 hover:text-white' }}">Home</a>
 
       <a href="/resumes"
          class="{{ 'text-white font-semibold' if active=='/resumes' else
-                  'text-blue-100 hover:text-white' }}">Résumés</a>
+                  'text-blue-200 hover:text-white' }}">Résumés</a>
 
       <a href="/chat"
          class="{{ 'text-white font-semibold' if active=='/chat' else
-                  'text-blue-100 hover:text-white' }}">Chat</a>
+                  'text-blue-200 hover:text-white' }}">Chat</a>
 
       {# profile for *any* logged-in user #}
       {% if user %}
         <a href="/profile"
            class="{{ 'text-white font-semibold' if active=='/profile' else
-                    'text-blue-100 hover:text-white' }}">Profile</a>
+                    'text-blue-200 hover:text-white' }}">Profile</a>
       {% endif %}
 
       {# owner-only admin page #}
       {% if user and user.role == 'owner' %}
         <a href="/admin/users"
            class="{{ 'text-white font-semibold' if active=='/admin/users' else
-                    'text-blue-100 hover:text-white' }}">Users</a>
+                    'text-blue-200 hover:text-white' }}">Users</a>
       {% endif %}
 
       {# login / logout #}
       {% if user %}
-        <a href="/logout" class="text-blue-100 hover:text-white">Logout</a>
+        <a href="/logout" class="text-blue-200 hover:text-white">Logout</a>
       {% else %}
         <a href="/login"
            class="{{ 'text-white font-semibold' if active=='/login' else
-                    'text-blue-100 hover:text-white' }}">Login</a>
+                    'text-blue-200 hover:text-white' }}">Login</a>
       {% endif %}
     </nav>
   </header>

--- a/templates/edit_resume.html
+++ b/templates/edit_resume.html
@@ -7,13 +7,13 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
   <link rel="stylesheet" href="/static/styles.css">
 </head>
-<body class="min-h-screen bg-gray-50 flex flex-col font-sans">
-  <header class="px-6 py-4 bg-gradient-to-r from-blue-800 to-blue-500 text-white shadow flex justify-between items-center">
+<body class="min-h-screen bg-gradient-to-br from-gray-100 to-gray-200 flex flex-col font-sans">
+  <header class="px-6 py-4 bg-gradient-to-r from-blue-900 to-blue-700 text-white shadow flex justify-between items-center">
     <h1 class="font-semibold text-xl">Edit résumé</h1>
-    <nav class="space-x-6 text-white">
-      <a href="/"        class="hover:underline">Home</a>
-      <a href="/resumes" class="hover:underline">All résumés</a>
-      <a href="/chat"    class="hover:underline">Chat</a>
+    <nav class="space-x-6 text-sm">
+      <a href="/" class="text-blue-200 hover:text-white">Home</a>
+      <a href="/resumes" class="text-blue-200 hover:text-white">All résumés</a>
+      <a href="/chat" class="text-blue-200 hover:text-white">Chat</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- tweak global body styling for a subtle gradient background
- darken the header gradient
- use lighter blue text for inactive links
- align edit page with new color scheme

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68405a1c39208330a6eb5b7d636a9a23