### PR TITLE
Add user editing and password reset for owner

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,6 +61,9 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 users_coll = db["users"]
 users_coll.create_index("username", unique=True)
 
+# default password used when resetting user accounts
+DEFAULT_PASSWORD = os.getenv("DEFAULT_PASS", "changeme!")
+
 # ── helpers ────────────────────────────────────────────────────────────────
 def render(request: Request,
            template_name: str,
@@ -888,6 +891,39 @@ def delete_user_admin(
     if res.deleted_count == 0:
         raise HTTPException(404, "User not found")
 
+    return RedirectResponse("/admin/users", status_code=303)
+
+
+@app.get("/admin/users/{username}/edit", response_class=HTMLResponse,
+         dependencies=[Depends(require_owner)])
+def edit_user_form(request: Request, username: str):
+    user = users_coll.find_one({"username": username}, {"_id": 0, "hashed_password": 0})
+    if not user:
+        raise HTTPException(404, "User not found")
+    return render(request, "edit_user.html",
+                  {"user": user},
+                  page_title="Edit user", active="/admin/users")
+
+
+@app.post("/admin/users/{username}/edit", dependencies=[Depends(require_owner)])
+def update_user_admin(username: str, new_username: str = Form(...)):
+    if username != new_username:
+        if users_coll.find_one({"username": new_username}):
+            raise HTTPException(400, "Username already exists")
+        res = users_coll.update_one({"username": username}, {"$set": {"username": new_username}})
+        if res.matched_count == 0:
+            raise HTTPException(404, "User not found")
+    return RedirectResponse("/admin/users", status_code=303)
+
+
+@app.post("/admin/users/{username}/reset", dependencies=[Depends(require_owner)])
+def reset_user_password(username: str):
+    res = users_coll.update_one(
+        {"username": username},
+        {"$set": {"hashed_password": pwd_context.hash(DEFAULT_PASSWORD)}}
+    )
+    if res.matched_count == 0:
+        raise HTTPException(404, "User not found")
     return RedirectResponse("/admin/users", status_code=303)
 
 

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -27,6 +27,7 @@
           <input type="hidden" name="username" value="{{ u.username }}">
           <button class="text-red-600 hover:underline">delete</button>
         </form>
+        <a href="/admin/users/{{ u.username }}/edit" class="text-blue-600 hover:underline">edit</a>
       </td>
     </tr>
     {% endfor %}

--- a/templates/edit_user.html
+++ b/templates/edit_user.html
@@ -1,0 +1,21 @@
+{% extends "_base.html" %}
+{% set page_title = "Edit user" %}
+{% set active = "/admin/users" %}
+
+{% block body %}
+<div class="max-w-lg mx-auto bg-white/70 backdrop-blur p-6 rounded-xl shadow">
+  <h2 class="text-2xl font-semibold mb-6">Edit user</h2>
+  <form action="/admin/users/{{ user.username }}/edit" method="post" class="space-y-4">
+    <div>
+      <label class="block font-medium mb-1">Username</label>
+      <input name="new_username" value="{{ user.username }}" class="w-full border px-3 py-2 rounded" required>
+    </div>
+    <button class="px-4 py-2 bg-blue-600 text-white rounded">Save changes</button>
+  </form>
+
+  <form action="/admin/users/{{ user.username }}/reset" method="post" class="mt-4"
+        onsubmit="return confirm('Reset password for {{ user.username }}?');">
+    <button class="px-4 py-2 bg-red-600 text-white rounded">Reset password</button>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow owners to edit usernames or reset a user's password
- link edit page from user admin list
- add new edit page template

## Testing
- `python -m py_compile main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68405a8a46008330b5814781d72bf46d