### PR TITLE
Add pytest setup and login tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Recruitment Assistant
+
+This FastAPI project provides recruitment-related features such as chat and resume management.
+
+## Running Tests
+
+1. Install Python dependencies (requires network access):
+
+```bash
+pip install -r requirements.txt
+pip install pytest
+```
+
+2. Execute the test suite with:
+
+```bash
+pytest
+```
+
+The tests use FastAPI's `TestClient` and check the login flow.

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ typing-inspection==0.4.0
 typing_extensions==4.13.2
 urllib3==2.4.0
 uvicorn==0.34.2
+pytest==8.1.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,60 @@
+import sys
+import types
+
+# stub heavy external modules so main can be imported without full dependencies
+mods = {
+    'mammoth': {},
+    'numpy': {'array': lambda x: x},
+    'openai': {},
+    'pdfplumber': {},
+    'PyPDF2': {},
+    'docx': {'Document': lambda *a, **k: None},
+    'httpx': {},
+    'dotenv': {'load_dotenv': lambda: None},
+    'certifi': {'where': lambda: ''},
+}
+for name, attrs in mods.items():
+    if name not in sys.modules:
+        mod = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(mod, k, v)
+        sys.modules[name] = mod
+
+# stub passlib with minimal CryptContext
+passlib_context = types.ModuleType('passlib.context')
+passlib_context.CryptContext = lambda **kw: types.SimpleNamespace(hash=lambda p: p, verify=lambda p, h: p == h)
+sys.modules['passlib.context'] = passlib_context
+passlib_hash = types.ModuleType('passlib.hash')
+passlib_hash.bcrypt = types.SimpleNamespace(hash=lambda p: p, verify=lambda p, h: p == h)
+sys.modules['passlib.hash'] = passlib_hash
+
+# stub Mongo and related modules used by db/mongo_utils
+pymongo = types.ModuleType('pymongo')
+pymongo.MongoClient = lambda *a, **k: None
+pymongo.errors = types.SimpleNamespace(PyMongoError=Exception)
+sys.modules['pymongo'] = pymongo
+bson = types.ModuleType('bson')
+bson.ObjectId = str
+sys.modules['bson'] = bson
+
+# stub custom helper modules used by main
+stub_db = types.ModuleType('db')
+stub_db.chat_find_one = lambda *a, **kw: None
+stub_db.chat_upsert = lambda *a, **kw: None
+stub_db.resumes_all = lambda: []
+stub_db.resumes_by_ids = lambda ids: []
+stub_db.resumes_collection = None
+sys.modules['db'] = stub_db
+
+stub_mongo_utils = types.ModuleType('mongo_utils')
+stub_mongo_utils.update_resume = lambda *a, **kw: None
+stub_mongo_utils.delete_resume_by_id = lambda *a, **kw: None
+stub_mongo_utils.db = {}
+sys.modules['mongo_utils'] = stub_mongo_utils
+
+stub_pinecone_utils = types.ModuleType('pinecone_utils')
+stub_pinecone_utils.add_resume_to_pinecone = lambda *a, **kw: None
+stub_pinecone_utils.embed_text = lambda *a, **kw: []
+stub_pinecone_utils.index = None
+stub_pinecone_utils.search_best_resumes = lambda *a, **kw: []
+sys.modules['pinecone_utils'] = stub_pinecone_utils

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+import types
+import main
+import pytest
+
+# disable startup DB seed
+if main.seed_owner in main.app.router.on_startup:
+    main.app.router.on_startup.remove(main.seed_owner)
+
+@pytest.fixture
+def client(monkeypatch):
+    def fake_verify(username: str, password: str):
+        if username == "user" and password == "pass":
+            return {"username": username, "role": "user"}
+        return None
+    monkeypatch.setattr(main, "verify_password", fake_verify)
+    with TestClient(main.app) as c:
+        yield c
+
+def test_login_page(client):
+    resp = client.get("/login")
+    assert resp.status_code == 200
+
+def test_login_success(client):
+    resp = client.post("/login", data={"username": "user", "password": "pass"}, allow_redirects=False)
+    assert resp.status_code == 303
+
+def test_login_failure(client):
+    resp = client.post("/login", data={"username": "bad", "password": "wrong"})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add basic README with test instructions
- include pytest dependency
- stub heavy modules for testing
- add login route tests using FastAPI TestClient

## Testing
- `pytest -q` *(fails: ModuleNotFoundError / AttributeError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68405aef93d0833089a3fcab0e46087d