### PR TITLE
Add favicon

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from docx import Document
 from dotenv import load_dotenv
 from fastapi import Body, FastAPI, File, Form, Request, UploadFile, Depends, HTTPException, status, Cookie
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, PlainTextResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, PlainTextResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from itsdangerous import URLSafeTimedSerializer, BadSignature
@@ -61,6 +61,11 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="static"), name="static")
 templates = Jinja2Templates(directory="templates")
+
+
+@app.get("/favicon.ico", include_in_schema=False)
+async def favicon():
+    return FileResponse("static/favicon.svg")
 
 
 # ═════════════════════════════════════════════════════════════════════════════

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#3498db"/>
+  <text x="32" y="38" text-anchor="middle" font-size="32" font-family="Arial" fill="white">RA</text>
+</svg>

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -6,6 +6,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
   <link rel="stylesheet" href="/static/styles.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 </head>
 
 <body class="min-h-screen bg-gradient-to-br from-gray-100 to-gray-200 font-sans">


### PR DESCRIPTION
## Summary
- add favicon file and route
- link favicon in base template

## Testing
- `pytest -q` *(fails: AttributeError: module 'httpx' has no attribute 'BaseTransport')*

------
https://chatgpt.com/codex/tasks/task_e_6841454b7dc08330bbb2dc6bd5fc36fc