### PR TITLE
Add multi-file resume upload

### DIFF
--- a/main.py
+++ b/main.py
@@ -409,44 +409,77 @@ async def upload_resume(
     user          = Depends(require_login),
     name: str     = Form(""),
     text: str     = Form(""),
-    file: UploadFile = File(None),
+    files: List[UploadFile] = File(None),
 ):
-    if file and file.filename:
-        data = await file.read()
-        text = extract_text(data, file.filename)
-        if not text:
-            return render(request, "index.html",
-                          {"popup": "Unsupported file type."},
-                          page_title="Home")
+    names = []
+    if files:
+        for f in files:
+            if not f or not f.filename:
+                continue
+            data = await f.read()
+            txt = extract_text(data, f.filename)
+            if not txt:
+                return render(
+                    request,
+                    "index.html",
+                    {"popup": "Unsupported file type."},
+                    page_title="Home",
+                )
+            if not txt.strip():
+                return render(
+                    request,
+                    "index.html",
+                    {"popup": "Résumé text is empty."},
+                    page_title="Home",
+                )
+
+            display_name = guess_name(name, f.filename, txt)
+            resume_id = slugify(display_name)
+            add_resume_to_pinecone(
+                txt,
+                resume_id,
+                {"name": display_name, "text": txt},
+                "resumes",
+            )
+            try:
+                resumes_collection.insert_one(
+                    {"resume_id": resume_id, "name": display_name, "text": txt}
+                )
+            except Exception as e:  # pragma: no cover
+                print("🛑 Mongo insert failed:", e)
+            names.append(display_name)
+        popup = f"{len(names)} résumé(s) added: {', '.join(names)}"
+        return render(request, "index.html", {"popup": popup}, page_title="Home")
 
     if not text.strip():
-        return render(request, "index.html",
-                      {"popup": "Résumé text is empty."},
-                      page_title="Home")
+        return render(
+            request,
+            "index.html",
+            {"popup": "Résumé text is empty."},
+            page_title="Home",
+        )
 
-    # ───── pick a *display* name & a stable ID ────────────────────────────
-    display_name = guess_name(name, file.filename if file else "", text)
-    resume_id    = slugify(display_name)     # or uuid if slug empty
-
-    # push to Pinecone
+    display_name = guess_name(name, "", text)
+    resume_id = slugify(display_name)
     add_resume_to_pinecone(
         text,
-        resume_id,                    # vector ID
-        {"name": display_name, "text": text},   # metadata
+        resume_id,
+        {"name": display_name, "text": text},
         "resumes",
     )
-
-    # push to Mongo
     try:
         resumes_collection.insert_one(
             {"resume_id": resume_id, "name": display_name, "text": text}
         )
-    except Exception as e:            # pragma: no cover
+    except Exception as e:  # pragma: no cover
         print("🛑 Mongo insert failed:", e)
 
-    return render(request, "index.html",
-                  {"popup": f"Résumé added: {display_name}"},
-                  page_title="Home")
+    return render(
+        request,
+        "index.html",
+        {"popup": f"Résumé added: {display_name}"},
+        page_title="Home",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,8 +16,9 @@
         autocomplete="off">
     <input id="resume-file"
            type="file"
-           name="file"
+           name="files"
            accept=".pdf,.docx"
+           multiple
            class="hidden">
     <p class="text-lg text-gray-500 mb-4 pointer-events-none">
       Drag &amp; drop a résumé PDF / DOCX here<br>
@@ -71,32 +72,14 @@
 const dropZone  = document.getElementById('resume-form');
 const fileInput = document.getElementById('resume-file');
 const browseBtn = document.getElementById('select-btn');
-const uploadsTb = document.querySelector('#uploads-table tbody');
 
-/* helper: add a new row without reloading */
-function prependRow(name, id){
-  const tr = document.createElement('tr');
-  tr.className = 'odd:bg-white even:bg-gray-50';
-  tr.innerHTML = `
-    <td class="px-4 py-2">${name}</td>
-    <td class="px-2 py-2">just now</td>
-    <td class="px-2 py-2 space-x-3">
-      <a href="/resumes#${id}" class="text-blue-600 hover:underline">edit</a>
-      <form action="/delete_resume" method="post" class="inline">
-        <input type="hidden" name="id" value="${id}">
-        <button class="text-red-600 hover:underline"
-                onclick="return confirm('Delete?')">delete</button>
-      </form>
-    </td>`;
-  uploadsTb.prepend(tr);
-}
 
 /* click → open picker */
 browseBtn.onclick = () => fileInput.click();
 
 /* picker → send via fetch */
 fileInput.onchange = () => {
-  if (fileInput.files.length) uploadFile(fileInput.files[0]);
+  if (fileInput.files.length) uploadFiles(fileInput.files);
 };
 
 /* drag-and-drop visual cues */
@@ -116,25 +99,22 @@ fileInput.onchange = () => {
 /* drop handler */
 dropZone.addEventListener('drop', e=>{
   if (e.dataTransfer.files.length){
-    uploadFile(e.dataTransfer.files[0]);
+    uploadFiles(e.dataTransfer.files);
   }
 });
 
 /* core upload logic */
-async function uploadFile(file){
+async function uploadFiles(files){
   const fd = new FormData();
-  fd.append('file', file);
+  for(const file of files) fd.append('files', file);
   /* you could collect additional fields here (e.g. name) */
 
   try{
     const res = await fetch('/upload_resume', {method:'POST', body: fd});
     if(!res.ok) throw new Error(await res.text());
 
-    const msg = await res.text();   // server returns full HTML page
-    // a cheap way: peek at the popup message to get the ID & name
-    const m = msg.match(/ID (\S+)\./);          // "... added with ID xyz."
-    const id = m ? m[1] : crypto.randomUUID();
-    prependRow(file.name, id);
+    await res.text();               // response not parsed
+    location.reload();
   }catch(err){
     alert('Upload failed: ' + err);
   }finally{

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,11 @@ mods = {
     'numpy': {'array': lambda x: x},
     'openai': {},
     'pdfplumber': {},
-    'PyPDF2': {},
+    'PyPDF2': {'PdfReader': lambda *a, **k: types.SimpleNamespace(pages=[])},
     'docx': {'Document': lambda *a, **k: None},
-    'httpx': {},
     'dotenv': {'load_dotenv': lambda: None},
     'certifi': {'where': lambda: ''},
+    'itsdangerous': {'URLSafeTimedSerializer': lambda *a, **k: None, 'BadSignature': Exception},
 }
 for name, attrs in mods.items():
     if name not in sys.modules:
@@ -19,6 +19,91 @@ for name, attrs in mods.items():
         for k, v in attrs.items():
             setattr(mod, k, v)
         sys.modules[name] = mod
+
+# minimal httpx stub for Starlette's TestClient
+if 'httpx' not in sys.modules:
+    httpx = types.ModuleType('httpx')
+
+    class Request:
+        def __init__(self, method, url):
+            from urllib.parse import urlsplit
+            parts = urlsplit(url)
+            self.method = method
+            self.url = types.SimpleNamespace(
+                scheme=parts.scheme or 'http',
+                netloc=parts.netloc.encode(),
+                path=parts.path,
+                raw_path=parts.path.encode(),
+                query=parts.query.encode(),
+            )
+            self.headers = {}
+            self._content = b''
+
+        def read(self):
+            return self._content
+
+    class ByteStream:
+        def __init__(self, data):
+            self._data = data
+
+        def read(self):
+            return self._data
+
+    class Response:
+        def __init__(self, status_code=200, headers=None, stream=None, request=None):
+            self.status_code = status_code
+            self.headers = headers or []
+            self.request = request
+            data = stream.read() if hasattr(stream, 'read') else b''
+            self.text = data.decode()
+            self.content = data
+
+    class BaseTransport:
+        pass
+
+    class Client:
+        def __init__(self, *args, **kwargs):
+            self._transport = kwargs.get('transport')
+            self.base_url = kwargs.get('base_url', '')
+
+        def request(self, method, url, **kwargs):
+            req = Request(method, self.base_url + url)
+            return self._transport.handle_request(req)
+
+        def get(self, url, **kwargs):
+            return self.request('GET', url, **kwargs)
+
+        def post(self, url, **kwargs):
+            return self.request('POST', url, **kwargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    httpx.Request = Request
+    httpx.Response = Response
+    httpx.ByteStream = ByteStream
+    httpx.Client = Client
+    httpx.BaseTransport = BaseTransport
+    httpx._client = types.SimpleNamespace(
+        USE_CLIENT_DEFAULT=object(),
+        CookieTypes=object,
+        UseClientDefault=object,
+        TimeoutTypes=object,
+    )
+    httpx._types = types.SimpleNamespace(
+        URLTypes=object,
+        HeaderTypes=object,
+        QueryParamTypes=object,
+        CookieTypes=object,
+        RequestContent=object,
+        RequestFiles=object,
+        AuthTypes=object,
+    )
+
+    sys.modules['httpx'] = httpx
 
 # stub passlib with minimal CryptContext
 passlib_context = types.ModuleType('passlib.context')
@@ -50,6 +135,9 @@ stub_mongo_utils = types.ModuleType('mongo_utils')
 stub_mongo_utils.update_resume = lambda *a, **kw: None
 stub_mongo_utils.delete_resume_by_id = lambda *a, **kw: None
 stub_mongo_utils.db = {}
+stub_mongo_utils._users = {}
+stub_mongo_utils.ENV = 'test'
+stub_mongo_utils._guard = lambda op: False
 sys.modules['mongo_utils'] = stub_mongo_utils
 
 stub_pinecone_utils = types.ModuleType('pinecone_utils')


### PR DESCRIPTION
## Summary
- allow `/upload_resume` to handle multiple files
- support multi-file form submission in the homepage
- stub additional modules for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'main')*

------
https://chatgpt.com/codex/tasks/task_e_6841451323188330abe47448af26ce09