### PR TITLE
Improve markdown sanitization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,5 @@ typing_extensions==4.13.2
 urllib3==2.4.0
 uvicorn==0.34.2
 pytest==8.1.1
+markdown==3.5.2
+bleach==6.1.0

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -31,7 +31,7 @@
                     {{ 'bg-blue-100' if msg.role=='user' else 'bg-rose-100' }}
                     whitespace-pre-wrap">
           <strong>{{ 'You' if msg.role=='user' else 'Assistant' }}:</strong>
-          {{ msg.content }}
+          {{ msg.content | safe }}
         </div>
       </div>
       {% endfor %}

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 from PyPDF2 import PdfReader
 from docx import Document
-from html import escape
-import re
+import markdown
+import bleach
 
 def extract_text_from_pdf(file):
     reader = PdfReader(file)
@@ -13,9 +13,18 @@ def extract_text_from_docx(file):
 
 
 def sanitize_markdown(md: str) -> str:
-    """Convert a small subset of Markdown to safe HTML."""
-    text = escape(md)
-    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
-    text = re.sub(r"\*(.+?)\*", r"<em>\1</em>", text)
-    text = text.replace("\n", "<br>")
-    return text
+    """Render markdown and sanitize the resulting HTML."""
+    html = markdown.markdown(md, extensions=["nl2br"])  # preserve single newlines
+    allowed_tags = [
+        "p",
+        "br",
+        "strong",
+        "em",
+        "ul",
+        "ol",
+        "li",
+        "pre",
+        "code",
+        "blockquote",
+    ]
+    return bleach.clean(html, tags=allowed_tags, strip=True)


### PR DESCRIPTION
## Summary
- include `markdown` and `bleach` dependencies
- sanitize markdown using these libraries
- render chat history using safe HTML

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'main')*

------
https://chatgpt.com/codex/tasks/task_e_68414ce25b588330832dc0596610afae