### PR TITLE
Use specific env file loading

### DIFF
--- a/pinecone_utils.py
+++ b/pinecone_utils.py
@@ -4,7 +4,10 @@ from pinecone import Pinecone, ServerlessSpec
 import openai
 
 env_file = ".env.production" if os.getenv("ENV", "development").lower() == "production" else ".env.development"
-load_dotenv()
+try:
+    load_dotenv(env_file)
+except TypeError:  # tests may stub load_dotenv without args
+    load_dotenv()
 
 ENV = os.getenv("ENV", "development").lower()
 


### PR DESCRIPTION
## Summary
- load the selected environment file in `main.py` and `pinecone_utils.py`
- handle tests that stub out `load_dotenv`
- gracefully fall back when minimal test stubs lack database features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'main')*

------
https://chatgpt.com/codex/tasks/task_e_68414d2fe3588330bb2330a443a85550