### PR TITLE
Fix upload field name

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -106,7 +106,7 @@ dropZone.addEventListener('drop', e=>{
 /* core upload logic */
 async function uploadFiles(files){
   const fd = new FormData();
-  for(const file of files) fd.append('files', file);
+  for(const file of files) fd.append('file', file);
   /* you could collect additional fields here (e.g. name) */
 
   try{


### PR DESCRIPTION
## Summary
- correct key when appending files in `uploadFiles` so `/upload_resume` receives `file`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68416f858bbc8330a7b5122c92265a4a