### PR TITLE
Fix user_id reference in match_project

### DIFF
--- a/main.py
+++ b/main.py
@@ -558,6 +558,8 @@ async def match_project(
     file: UploadFile = File(None),
     candidate_ids: Optional[List[str]] = Form(None),
 ):
+    session_user = get_current_user(request.cookies.get(COOKIE_NAME))
+    user_id = session_user["username"] if session_user else "anon"
     # 1️⃣ extract text --------------------------------------------------------
     if file and file.filename:
         data = await file.read()


### PR DESCRIPTION
## Summary
- ensure /match_project defines `user_id` before saving history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841829d57e48330b1e868c58c566b46