### PR TITLE
Add project deletion feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ from mongo_utils import (
     resumes_by_ids,
     resumes_collection,
     add_project_history,
+    delete_project,
 )
 from pymongo import errors
 from pinecone_utils import (
@@ -783,6 +784,20 @@ def project_history(request: Request, user=Depends(require_login)):
         page_title="Projects",
         active="/projects",
     )
+
+
+@app.post("/delete_project")
+def delete_project_route(request: Request,
+                         ts: str = Form(...),
+                         user=Depends(require_login)):
+    session_user = get_current_user(request.cookies.get(COOKIE_NAME))
+    user_id = session_user["username"] if session_user else "anon"
+    deleted = delete_project(user_id, ts)
+    if deleted == 0:
+        print(f"🛑 No project found with ts {ts}")
+    else:
+        print(f"🟢 Deleted project with ts {ts}")
+    return RedirectResponse("/projects", status_code=303)
 
 @app.get("/view_resumes", response_class=HTMLResponse)
 async def view_resumes(request: Request, user=Depends(require_login)):

--- a/mongo_utils.py
+++ b/mongo_utils.py
@@ -191,3 +191,18 @@ def add_project_history(user_id: str, project: dict):
         {"$push": {"projects": project}, "$set": {"last_project": project, "ts": datetime.utcnow()}},
         upsert=True,
     )
+
+
+def delete_project(user_id: str, ts_iso: str) -> int:
+    """Delete a project by timestamp for the given user."""
+    if _guard("delete_project"):
+        return 0
+    try:
+        ts = datetime.fromisoformat(ts_iso)
+    except ValueError:
+        return 0
+    res = chats.update_one(
+        {"user_id": user_id},
+        {"$pull": {"projects": {"ts": ts}}},
+    )
+    return res.modified_count

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -3,13 +3,20 @@
 {% set page_title = "Projects" %}
 
 {% block body %}
-<div class="space-y-6">
+<div class="space-y-4">
   {% if projects %}
     {% for p in projects %}
-      <section class="bg-white/70 backdrop-blur p-4 rounded shadow">
-        <div class="mb-2 text-sm whitespace-pre-wrap">{{ p.description }}</div>
+      <details class="bg-white/70 backdrop-blur p-4 rounded shadow">
+        <summary class="cursor-pointer">
+          {{ p.description|truncate(80, True, '…') }}
+        </summary>
+        <div class="mt-2 text-sm whitespace-pre-wrap">{{ p.description }}</div>
         <div class="overflow-auto">{{ p.table_html | safe }}</div>
-      </section>
+        <form action="/delete_project" method="post" class="mt-2">
+          <input type="hidden" name="ts" value="{{ p.ts.isoformat() }}">
+          <button type="submit" class="text-red-600 text-sm hover:underline" onclick="return confirm('Delete project?')">delete</button>
+        </form>
+      </details>
     {% endfor %}
   {% else %}
     <p>No past projects found.</p>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -347,6 +347,7 @@ stub_mongo_utils.resumes_all = lambda: []
 stub_mongo_utils.resumes_by_ids = lambda ids: []
 stub_mongo_utils.resumes_collection = None
 stub_mongo_utils.add_project_history = lambda *a, **kw: None
+stub_mongo_utils.delete_project = lambda *a, **kw: 1
 
 class DummyColl:
     def __getattr__(self, name):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,3 +38,8 @@ async def test_chat_json(authed):
     resp = await main.chat(DummyRequest("/chat"), chat_data=main.ChatRequest(text="hello", candidate_ids=[]))
     assert resp.status_code == 200
     assert resp.body == b'{"reply":"hi"}' or resp.body == b'{"reply": "hi"}'
+
+
+def test_delete_project(authed):
+    resp = main.delete_project_route(DummyRequest("/delete_project"), ts="2023-01-01T00:00:00")
+    assert resp.status_code == 303


### PR DESCRIPTION
## Summary
- allow deleting project history items in mongo
- expose `/delete_project` route
- condense project list with `<details>` and delete button
- update stubs and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684183cbead88330ace7725159bca588