### PR TITLE
Centralize environment settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,6 @@ import openai
 import pdfplumber
 import PyPDF2
 from docx import Document
-from dotenv import load_dotenv
 from fastapi import Body, FastAPI, File, Form, Request, UploadFile, Depends, HTTPException, status, Cookie
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, PlainTextResponse, FileResponse
@@ -24,6 +23,8 @@ from itsdangerous import URLSafeTimedSerializer, BadSignature
 from starlette.responses import RedirectResponse
 from passlib.context import CryptContext
 from datetime import datetime
+
+from settings import settings
 
 
 # ── local helper modules ──────────────────────────────────────────────────────
@@ -52,9 +53,6 @@ from pinecone_utils import (
 from utils import sanitize_markdown
 from schemas import ResumeUpload, ChatRequest
 
-env_file = ".env.production" if os.getenv("ENV", "development").lower() == "production" else ".env.development"
-load_dotenv(env_file)
-
 if ENV == "production":
     _users.create_index("username", unique=True)
 else:
@@ -63,7 +61,7 @@ else:
     except errors.PyMongoError:
         pass
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
+openai.api_key = settings.OPENAI_API_KEY
 
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="static"), name="static")
@@ -85,7 +83,7 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 users_coll = db["users"]
 
 # default password used when resetting user accounts
-DEFAULT_PASSWORD = os.getenv("DEFAULT_PASS", "changeme!")
+DEFAULT_PASSWORD = settings.DEFAULT_PASS
 
 # ── helpers ────────────────────────────────────────────────────────────────
 def render(request: Request,
@@ -130,7 +128,7 @@ def verify_password(username: str, password: str):
     return None
 
 # ── signed-cookie session ──────────────────────────────────────────────────
-SECRET_KEY = os.getenv("SESSION_SECRET", "dev-secret")   # set a strong one!
+SECRET_KEY = settings.SESSION_SECRET   # set a strong one!
 signer = URLSafeTimedSerializer(SECRET_KEY, salt="auth-cookie")
 COOKIE_NAME = "session"
 
@@ -178,8 +176,8 @@ def seed_owner() -> None:
 
     if users_coll.count_documents({"role": "owner"}) == 0:
         create_user(
-            os.getenv("OWNER_USER", "owner"),
-            os.getenv("OWNER_PASS", "changeme!"),
+            settings.OWNER_USER,
+            settings.OWNER_PASS,
             role="owner"
         )
         print("🟢 Created initial owner account")

--- a/mongo_utils.py
+++ b/mongo_utils.py
@@ -1,28 +1,24 @@
 # mongo_utils.py – environment-aware Mongo setup (dev vs prod)
-import os
 import certifi
 import logging
 from datetime import datetime
 from types import SimpleNamespace
 from typing import List
 
-from dotenv import load_dotenv
 from pymongo import MongoClient, errors
 from bson import ObjectId
 from passlib.hash import bcrypt
 
+from settings import settings
 from pinecone_utils import add_resume_to_pinecone
-
-env_file = ".env.production" if os.getenv("ENV", "development").lower() == "production" else ".env.development"
-load_dotenv(env_file)
 
 # ------------------------------------------------------------------ #
 # 0) environment & configuration                                     #
 # ------------------------------------------------------------------ #
-ENV = os.getenv("ENV", "development").lower()
+ENV = settings.ENV
 
-MONGO_URI = os.environ["MONGO_URI"]            # Atlas SRV string for both envs
-DB_NAME   = "recruitment_app" if ENV == "production" else "recruitment_app_dev"
+MONGO_URI = settings.MONGO_URI            # Atlas SRV string for both envs
+DB_NAME = settings.db_name
 
 if ENV == "production":
     client = MongoClient(

--- a/pinecone_utils.py
+++ b/pinecone_utils.py
@@ -1,22 +1,17 @@
-import os
-from dotenv import load_dotenv
 from pinecone import Pinecone, ServerlessSpec
 import openai
 
-env_file = ".env.production" if os.getenv("ENV", "development").lower() == "production" else ".env.development"
-load_dotenv(env_file)
+from settings import settings
 
-ENV = os.getenv("ENV", "development").lower()
+ENV = settings.ENV
 
-openai.api_key = os.environ["OPENAI_API_KEY"]
-pc  = Pinecone(api_key=os.environ["PINECONE_API_KEY"])
+openai.api_key = settings.OPENAI_API_KEY
+pc = Pinecone(api_key=settings.PINECONE_API_KEY)
 
 # picks resumes-index for prod, resumes-dev for dev unless overridden
-INDEX_NAME = os.getenv(
-    "PINECONE_INDEX",
-    "resumes-index" if ENV == "production" else "resumes-dev"
-)
-PINECONE_ENV = os.environ["PINECONE_ENV"]
+INDEX_NAME = settings.pinecone_index
+PINECONE_ENV = settings.PINECONE_ENV
+
 
 def _ensure_index():
     if INDEX_NAME not in pc.list_indexes().names():

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,40 @@
+from functools import lru_cache
+import os
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    ENV: str = "development"
+    MONGO_URI: str = "mongodb://localhost:27017"
+    OPENAI_API_KEY: str = ""
+    PINECONE_API_KEY: str = ""
+    PINECONE_ENV: str = ""
+    PINECONE_INDEX: str | None = None
+    DEFAULT_PASS: str = "changeme!"
+    SESSION_SECRET: str = "dev-secret"
+    OWNER_USER: str = "owner"
+    OWNER_PASS: str = "changeme!"
+
+    class Config:
+        env_file = (
+            ".env.production"
+            if os.getenv("ENV", "development").lower() == "production"
+            else ".env.development"
+        )
+        case_sensitive = False
+
+    @property
+    def db_name(self) -> str:
+        return "recruitment_app" if self.ENV == "production" else "recruitment_app_dev"
+
+    @property
+    def pinecone_index(self) -> str:
+        if self.PINECONE_INDEX:
+            return self.PINECONE_INDEX
+        return "resumes-index" if self.ENV == "production" else "resumes-dev"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()
+
+settings = get_settings()


### PR DESCRIPTION
## Summary
- introduce `settings.py` for unified environment configuration
- refactor modules to use the shared `settings` object
- simplify environment handling in `main.py`, `mongo_utils.py`, and `pinecone_utils.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418655029c8330a2342f487f25d518