### PR TITLE
Add upload file validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -434,6 +434,11 @@ def slugify(val: str) -> str:
         or str(uuid.uuid4())          # absolute fallback
     )
 
+# ── upload validation constants --------------------------------------------
+ALLOWED_EXTENSIONS = {".pdf", ".docx"}
+# default max file size: 5 MB
+MAX_FILE_SIZE = 5 * 1024 * 1024
+
 # ── main upload handler --------------------------------------------------
 @app.post("/upload_resume", response_class=HTMLResponse)
 async def upload_resume(
@@ -490,8 +495,13 @@ async def upload_resume(
             added_names.append(display_name)
 
         for f in files:
-            filename = f.filename
+            filename = f.filename or ""
+            ext = os.path.splitext(filename)[1].lower()
+            if ext not in ALLOWED_EXTENSIONS:
+                continue
             data = await f.read()
+            if len(data) > MAX_FILE_SIZE:
+                continue
             file_text = extract_text(data, filename)
             if not file_text.strip():
                 continue

--- a/tests/test_upload_resume.py
+++ b/tests/test_upload_resume.py
@@ -44,3 +44,30 @@ def test_upload_resume_file_upload(client, monkeypatch):
     assert resp.status_code == 200
     assert len(stored) == 1
     assert stored[0]["text"] == "PDF text"
+
+
+def test_upload_resume_invalid_extension(client, monkeypatch):
+    c, stored = client
+
+    def fail(*a, **k):
+        raise AssertionError("extract_text should not be called")
+
+    monkeypatch.setattr(main, "extract_text", fail)
+    files = {"file": ("resume.txt", b"ignored")}
+    resp = c.post("/upload_resume", files=files)
+    assert resp.status_code == 200
+    assert len(stored) == 0
+
+
+def test_upload_resume_too_large(client, monkeypatch):
+    c, stored = client
+    monkeypatch.setattr(main, "MAX_FILE_SIZE", 10)
+
+    def fail(*a, **k):
+        raise AssertionError("extract_text should not be called")
+
+    monkeypatch.setattr(main, "extract_text", fail)
+    files = {"file": ("resume.pdf", b"x" * 20)}
+    resp = c.post("/upload_resume", files=files)
+    assert resp.status_code == 200
+    assert len(stored) == 0


### PR DESCRIPTION
## Summary
- validate upload file size and type for resume uploads
- test invalid extension and too large uploads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418e89d6f0833093cde1e730f2bcf7