### PR TITLE
Add resume tagging

### DIFF
--- a/pinecone_utils.py
+++ b/pinecone_utils.py
@@ -51,10 +51,14 @@ DEFAULT_NAMESPACE = "resumes"  # namespace stays the same in both envs
 def add_resume_to_pinecone(
     text: str,
     candidate_id: str,
-    metadata: dict,
+    metadata: dict | None = None,
     namespace: str = DEFAULT_NAMESPACE,
+    tags: list[str] | None = None,
 ):
     """Insert or update a résumé vector in Pinecone."""
+    metadata = metadata.copy() if metadata else {}
+    if tags is not None:
+        metadata["tags"] = tags
     vector = embed_text(text)
     if not vector or len(vector) != 1536:
         logger.warning(

--- a/schemas.py
+++ b/schemas.py
@@ -7,6 +7,7 @@ class ResumeUpload(BaseModel):
     skills: Optional[List[str]] = None
     location: Optional[str] = None
     years: Optional[int] = None
+    tags: Optional[List[str]] = None
 
 class ChatRequest(BaseModel):
     text: str


### PR DESCRIPTION
## Summary
- allow adding tags to resumes via JSON or form upload
- store tags in Mongo and Pinecone metadata
- include tags in project matching prompt
- support tags when updating resumes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419ac4f34c8330bffc7eefaff68146