### PR TITLE
Add resume filter fields

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -4,6 +4,9 @@ from typing import List, Optional
 class ResumeUpload(BaseModel):
     name: Optional[str] = ""
     text: str
+    skills: Optional[List[str]] = None
+    location: Optional[str] = None
+    years: Optional[int] = None
 
 class ChatRequest(BaseModel):
     text: str

--- a/templates/edit_resume.html
+++ b/templates/edit_resume.html
@@ -24,6 +24,24 @@
     </div>
 
     <div>
+      <label class="block font-medium mb-1">Location</label>
+      <input name="location" value="{{ resume.location }}"
+             class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+    </div>
+
+    <div>
+      <label class="block font-medium mb-1">Skills (comma separated)</label>
+      <input name="skills" value="{{ resume.skills }}"
+             class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+    </div>
+
+    <div>
+      <label class="block font-medium mb-1">Years of Experience</label>
+      <input type="number" name="years" value="{{ resume.years }}"
+             class="w-32 border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+    </div>
+
+    <div>
       <label class="block font-medium mb-1">Text</label>
       <textarea name="text"
                 rows="18"

--- a/templates/resume_rank_table.html
+++ b/templates/resume_rank_table.html
@@ -1,12 +1,10 @@
-<html>
-<head></head>
-<body>
-  <table style="width:100%; border-collapse: collapse; margin: 15px 0;">
+<table style="width:100%; border-collapse: collapse; margin: 15px 0;">
     <thead>
       <tr>
         <th style="border:1px solid #ccc; padding:8px; text-align:left;">Candidate</th>
-        <th style="border:1px solid #ccc; padding:8px; text-align:left;">Why Fit?</th>
         <th style="border:1px solid #ccc; padding:8px; text-align:left;">Fit</th>
+        <th style="border:1px solid #ccc; padding:8px; text-align:left;">Req OK</th>
+        <th style="border:1px solid #ccc; padding:8px; text-align:left;">Why Fit?</th>
         <th style="border:1px solid #ccc; padding:8px; text-align:left;">Improve</th>
       </tr>
     </thead>
@@ -14,12 +12,11 @@
       {% for row in rows %}
       <tr>
         <td style="border:1px solid #ccc; padding:8px;">{{ row.name }}</td>
-        <td style="border:1px solid #ccc; padding:8px;">{{ row.why }}</td>
         <td style="border:1px solid #ccc; padding:8px;">{{ row.fit }}</td>
+        <td style="border:1px solid #ccc; padding:8px;">{{ row.req_ok }}</td>
+        <td style="border:1px solid #ccc; padding:8px;">{{ row.why }}</td>
         <td style="border:1px solid #ccc; padding:8px;">{{ row.improve }}</td>
       </tr>
       {% endfor %}
     </tbody>
-  </table>
-</body>
-</html>
+</table>

--- a/templates/resumes.html
+++ b/templates/resumes.html
@@ -9,6 +9,19 @@
   <input id="search" type="text" placeholder="Search…"
          class="mb-4 w-64 px-3 py-2 border rounded">
 
+  <!-- server-side filters -->
+  <form method="get" class="mb-4 space-x-2 text-sm">
+    <input name="skill" placeholder="Skill" value="{{ skill }}"
+           class="px-2 py-1 border rounded">
+    <input name="location" placeholder="Location" value="{{ location }}"
+           class="px-2 py-1 border rounded">
+    <input name="min_years" type="number" placeholder="Min years"
+           value="{{ min_years }}" class="w-24 px-2 py-1 border rounded">
+    <input name="max_years" type="number" placeholder="Max years"
+           value="{{ max_years }}" class="w-24 px-2 py-1 border rounded">
+    <button class="px-2 py-1 bg-indigo-600 text-white rounded">Filter</button>
+  </form>
+
   <!-- résumé table -->
   <table id="cv-table"
          class="w-full text-sm border rounded-xl overflow-hidden shadow">
@@ -59,13 +72,13 @@
 
   <div class="flex justify-between items-center mt-4 text-sm">
     {% if prev_page %}
-      <a href="/resumes?page={{ prev_page }}" class="text-blue-600 hover:underline">&laquo; Prev</a>
+      <a href="/resumes?page={{ prev_page }}{% if qs %}&{{ qs }}{% endif %}" class="text-blue-600 hover:underline">&laquo; Prev</a>
     {% else %}
       <span></span>
     {% endif %}
     <span>Page {{ page }} of {{ pages }}</span>
     {% if next_page %}
-      <a href="/resumes?page={{ next_page }}" class="text-blue-600 hover:underline">Next &raquo;</a>
+      <a href="/resumes?page={{ next_page }}{% if qs %}&{{ qs }}{% endif %}" class="text-blue-600 hover:underline">Next &raquo;</a>
     {% else %}
       <span></span>
     {% endif %}


### PR DESCRIPTION
## Summary
- allow additional resume metadata fields like skills, location and years of experience
- support uploading and editing the new fields
- add server-side filtering by those fields on the resumes page
- keep pagination links working with filters
- fix resume ranking table fragment so it inserts correctly in chat

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68419505ffa883309fa17a44d4bcfa2f