### PR TITLE
Fix chat table markup

### DIFF
--- a/mongo_utils.py
+++ b/mongo_utils.py
@@ -144,6 +144,18 @@ async def update_resume(
         meta["tags"] = tags
     elif old.get("tags"):
         meta["tags"] = old.get("tags")
+    if skills is not None:
+        meta["skills"] = skills
+    elif old.get("skills"):
+        meta["skills"] = old.get("skills")
+    if location is not None:
+        meta["location"] = location
+    elif old.get("location"):
+        meta["location"] = old.get("location")
+    if years is not None:
+        meta["years"] = years
+    elif old.get("years") is not None:
+        meta["years"] = old.get("years")
 
     if text.strip() != old.get("text", ""):
         add_resume_to_pinecone(

--- a/templates/resume_rank_table.html
+++ b/templates/resume_rank_table.html
@@ -1,25 +1,24 @@
-<html>
-<head></head>
-<body>
-  <table style="width:100%; border-collapse: collapse; margin: 15px 0;">
-    <thead>
-      <tr>
-        <th style="border:1px solid #ccc; padding:8px; text-align:left;">Candidate</th>
-        <th style="border:1px solid #ccc; padding:8px; text-align:left;">Why Fit?</th>
-        <th style="border:1px solid #ccc; padding:8px; text-align:left;">Fit</th>
-        <th style="border:1px solid #ccc; padding:8px; text-align:left;">Improve</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for row in rows %}
-      <tr>
-        <td style="border:1px solid #ccc; padding:8px;">{{ row.name }}</td>
-        <td style="border:1px solid #ccc; padding:8px;">{{ row.why }}</td>
-        <td style="border:1px solid #ccc; padding:8px;">{{ row.fit }}</td>
-        <td style="border:1px solid #ccc; padding:8px;">{{ row.improve }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</body>
-</html>
+<table class="min-w-full border-collapse border border-gray-300 text-sm my-3">
+  <thead class="bg-gray-100">
+    <tr>
+      <th class="border px-2 py-1 text-left">Candidate</th>
+      <th class="border px-2 py-1 text-center">Fit&nbsp;%</th>
+      <th class="border px-2 py-1 text-center">
+        {% if expected_years %}Yrs/{{ expected_years }}{% else %}Yrs{% endif %}
+      </th>
+      <th class="border px-2 py-1 text-left">Why Fit?</th>
+      <th class="border px-2 py-1 text-left">Improve</th>
+    </tr>
+  </thead>
+  <tbody class="bg-white">
+    {% for row in rows %}
+    <tr>
+      <td class="border px-2 py-1 font-medium">{{ row.name }}</td>
+      <td class="border px-2 py-1 text-center">{{ row.fit }}</td>
+      <td class="border px-2 py-1 text-center">{{ row.years }}</td>
+      <td class="border px-2 py-1">{{ row.why }}</td>
+      <td class="border px-2 py-1">{{ row.improve }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,13 @@
 import re
+import types
 import pytest
 import main
 
+
+class DummyRequest:
+    def __init__(self, path="/"):
+        self.url = types.SimpleNamespace(path=path)
+        self.cookies = {}
 
 def test_guess_name_priority():
     # explicit name has highest priority
@@ -50,3 +56,58 @@ async def test_match_project_logic_error(monkeypatch):
     monkeypatch.setattr(main, "embed_text", lambda text: None)
     result = await main.match_project_logic("desc")
     assert "embed project description" in result
+
+
+def test_extract_years_requirement():
+    assert main.extract_years_requirement("need 5 years of experience") == 5
+    assert main.extract_years_requirement("minimum 3 years experience") == 3
+    assert main.extract_years_requirement("no numbers") is None
+
+
+@pytest.mark.asyncio
+async def test_match_project_years_column(monkeypatch):
+    table = (
+        "| Candidate | Fit % | Why Fit? | Improve |\n"
+        "|:--|:--:|:--|:--|\n"
+        "| Alice | 90 | ok | - |\n"
+        "| Bob | 80 | ok | - |"
+    )
+    fake_openai = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(
+                create=lambda **kw: types.SimpleNamespace(
+                    choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=table))]
+                )
+            )
+        )
+    )
+    monkeypatch.setattr(main, "openai", fake_openai)
+    monkeypatch.setattr(main, "embed_text", lambda text: [0.0] * 1536)
+
+    class DummyMatch:
+        def __init__(self, name, years):
+            self.id = name
+            self.values = [0.0] * 1536
+            self.metadata = {"name": name, "text": "resume", "years": years}
+
+    class DummyIndex:
+        def query(self, *a, **k):
+            return types.SimpleNamespace(matches=[
+                DummyMatch("Alice", 2),
+                DummyMatch("Bob", 4),
+            ])
+
+    monkeypatch.setattr(main, "index", DummyIndex())
+    monkeypatch.setattr(main, "add_project_history", lambda *a, **k: None)
+    async def _req_login():
+        return {"username": "u"}
+    async def _cur_user(*a, **k):
+        return {"username": "u"}
+    monkeypatch.setattr(main, "require_login", _req_login)
+    monkeypatch.setattr(main, "get_current_user", _cur_user)
+
+    resp = await main.match_project(
+        DummyRequest("/match"),
+        description="need 3 years", file=None, candidate_ids=None
+    )
+    assert "2/3" in resp.body.decode()


### PR DESCRIPTION
## Summary
- show candidate experience vs project expectation in chat ranking table
- render years column in table template
- test experience column injection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a00ada8483309777fa74de39951a