### PR TITLE
Add quick prompts to chat

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -6,6 +6,13 @@ from schemas import ChatRequest
 
 router = APIRouter()
 
+# default set of quick prompt templates shown in the chat UI
+QUICK_PROMPTS = [
+    "Rewrite my resume for the [Insert job title] role",
+    "Summarize candidate strengths for a [Insert job title] role",
+    "List key skills for a [Insert job title] role",
+]
+
 @router.get("/chat", response_class=HTMLResponse)
 async def chat_interface(request: Request, user=Depends(main.require_login)):
     candidates = [{"id": r["resume_id"], "name": r["name"]} for r in await main.resumes_all()]
@@ -22,7 +29,11 @@ async def chat_interface(request: Request, user=Depends(main.require_login)):
     return await main.render(
         request,
         "chat.html",
-        {"history": safe_history, "candidates": candidates},
+        {
+            "history": safe_history,
+            "candidates": candidates,
+            "quick_prompts": QUICK_PROMPTS,
+        },
         page_title="Chat",
     )
 
@@ -111,7 +122,11 @@ async def chat_action(
     return await main.render(
         request,
         "chat.html",
-        {"reply": safe_reply, "candidates": candidates},
+        {
+            "reply": safe_reply,
+            "candidates": candidates,
+            "quick_prompts": QUICK_PROMPTS,
+        },
         page_title="Chat",
     )
 

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -35,10 +35,19 @@
         </div>
       </div>
       {% endfor %}
-    </div>
+      </div>
 
-    {# input row #}
-    <div class="border-t bg-white/70 backdrop-blur p-4 flex items-center gap-2">
+      {# quick prompts row #}
+      <div id="quick-prompts" class="border-t bg-white/70 backdrop-blur p-4 flex flex-wrap gap-2">
+        {% for pr in quick_prompts %}
+        <button type="button" class="quick-prompt bg-gray-200 px-2 py-1 rounded" data-text="{{ pr }}">
+          {{ pr }}
+        </button>
+        {% endfor %}
+      </div>
+
+      {# input row #}
+      <div class="border-t bg-white/70 backdrop-blur p-4 flex items-center gap-2">
       <button id="attach-btn" title="Upload project"
               class="p-2 rounded bg-gray-200">📎</button>
       <input id="project-file" type="file" accept=".pdf,.docx" class="hidden">
@@ -75,6 +84,24 @@ function addBubble(role, html) {
        </div>
      </div>`);
   qs('#chat-box').scrollTop = qs('#chat-box').scrollHeight;
+}
+
+// ── send prompt template ------------------------------------
+async function sendPrompt(raw) {
+  let finalText = raw;
+  if (raw.includes('[Insert job title]')) {
+    const title = prompt('Job title?');
+    if (title === null) return;
+    finalText = raw.replace('[Insert job title]', title);
+  }
+  addBubble('user', finalText);
+  const res = await fetch('/chat', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ text: finalText, candidate_ids: selected() })
+  });
+  const data = await res.json();
+  addBubble('assist', data.reply);
 }
 
 // ── sidebar filter ──────────────────────────────────────────
@@ -114,6 +141,11 @@ qs('#project-file').onchange = async e => {
   addBubble('assist', html);
   e.target.value = '';
 };
+
+// ── quick prompt buttons ------------------------------------
+document.querySelectorAll('#quick-prompts button').forEach(btn => {
+  btn.onclick = () => sendPrompt(btn.dataset.text);
+});
 
 // ── scroll to bottom on initial load ────────────────────────
 window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- inject quick prompt templates for chat page
- render quick prompt buttons in `chat.html`
- implement `sendPrompt()` JS helper for quick prompts
- connect quick prompt buttons to new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d5f18fc08330a5bf0c1dd314b6a2