### PR TITLE
Implement sidebar layout and modern home page

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,24 +1,42 @@
 /* Custom global styles */
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: 'Manrope', sans-serif;
   background: linear-gradient(135deg, #eef2ff, #f8fafc);
   min-height: 100vh;
   color: #1e293b;
+  transition: background 0.3s ease, color 0.3s ease;
 }
-
+body.dark {
+  background: linear-gradient(135deg, #1e293b, #334155);
+  color: #f1f5f9;
+}
 header {
   background: rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(12px);
 }
-
 .card {
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(8px);
   border-radius: 0.75rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   padding: 1.5rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
-
+.dark .card {
+  background: rgba(30, 41, 59, 0.7);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
 input, textarea, select {
   border-color: #d1d5db;
+}
+#resume-form.drag-over {
+  box-shadow: 0 0 0 4px rgba(59,130,246,0.4);
+  transform: scale(1.02);
+}
+@keyframes pop {
+  from { opacity:0; transform: scale(0.95); }
+  to   { opacity:1; transform: scale(1); }
+}
+.animate-pop {
+  animation: pop 0.4s ease;
 }

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -4,75 +4,55 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="/static/styles.css">
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <title>{{ page_title }} - Recruitment Assistant</title>
 </head>
-
 <body class="font-sans">
-  {# ------------------------------------------------------------- #
-     expect three template variables to be present:
-
-       active  → the current path  ('/', '/resumes', etc.)
-       user    → None or a dict     {"username": "...", "role": "..."}
-       page_title → page headline
-
-     (pass  user=current_user  whenever you call TemplateResponse)
-  # ------------------------------------------------------------- #}
-  <header class="fixed top-0 inset-x-0 h-16 bg-white/80 backdrop-blur-md shadow-md flex items-center justify-between px-8">
-    <span class="font-semibold text-indigo-600">Recruitment Assistant</span>
-
-    <nav class="space-x-6 text-sm">
-      {# regular links #}
-      <a href="/"
-         class="{{ 'text-indigo-600 font-semibold' if active=='/' else
-                  'text-gray-700 hover:text-indigo-600' }}">Home</a>
-
-      <a href="/resumes"
-         class="{{ 'text-indigo-600 font-semibold' if active=='/resumes' else
-                  'text-gray-700 hover:text-indigo-600' }}">Résumés</a>
-
-      <a href="/chat"
-         class="{{ 'text-indigo-600 font-semibold' if active=='/chat' else
-                  'text-gray-700 hover:text-indigo-600' }}">Chat</a>
-
-      <a href="/projects"
-         class="{{ 'text-indigo-600 font-semibold' if active=='/projects' else
-                  'text-gray-700 hover:text-indigo-600' }}">Projects</a>
-
-      {# profile for *any* logged-in user #}
+<div class="flex min-h-screen">
+  <aside class="hidden sm:flex fixed inset-y-0 left-0 w-64 flex-col bg-white/70 backdrop-blur-lg shadow-xl p-4">
+    <div class="flex items-center justify-between mb-6">
+      <span class="text-lg font-semibold text-indigo-600">Recruitment Assistant</span>
+      <button id="mode-toggle" class="text-gray-600"><i class="fa-solid fa-moon"></i></button>
+    </div>
+    <nav class="flex-1 space-y-2 text-sm">
+      <a href="/" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-house"></i>Home</a>
+      <a href="/resumes" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/resumes' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-file-lines"></i>Résumés</a>
+      <a href="/chat" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/chat' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-comments"></i>Chat</a>
+      <a href="/projects" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/projects' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-table-list"></i>Projects</a>
       {% if user %}
-        <a href="/profile"
-           class="{{ 'text-indigo-600 font-semibold' if active=='/profile' else
-                    'text-gray-700 hover:text-indigo-600' }}">Profile</a>
+        <a href="/profile" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/profile' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-user"></i>Profile</a>
       {% endif %}
-
-      {# owner-only admin page #}
       {% if user and user.role == 'owner' %}
-        <a href="/admin/users"
-           class="{{ 'text-indigo-600 font-semibold' if active=='/admin/users' else
-                    'text-gray-700 hover:text-indigo-600' }}">Users</a>
-      {% endif %}
-
-      {# login / logout #}
-      {% if user %}
-        <a href="/logout" class="text-gray-700 hover:text-indigo-600">Logout</a>
-      {% else %}
-        <a href="/login"
-           class="{{ 'text-indigo-600 font-semibold' if active=='/login' else
-                    'text-gray-700 hover:text-indigo-600' }}">Login</a>
+        <a href="/admin/users" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/admin/users' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-users"></i>Users</a>
       {% endif %}
     </nav>
-  </header>
-
-  <main class="pt-20 p-6">
-    {% if page_title %}
-      <h1 class="text-2xl font-semibold px-6 mb-4">{{ page_title }}</h1>
-    {% endif %}
-    {% block body %}{% endblock %}
-  </main>
-
-  {% block extra_js %}{% endblock %}
+    <div class="mt-auto pt-4 border-t flex items-center justify-between text-sm">
+      {% if user %}
+        <span class="truncate">{{ user.username }}</span>
+        <a href="/logout" class="text-gray-700 hover:text-red-600 flex items-center gap-1"><i class="fa-solid fa-right-from-bracket"></i>Logout</a>
+      {% else %}
+        <a href="/login" class="text-gray-700 hover:text-indigo-600 flex items-center gap-1"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
+      {% endif %}
+    </div>
+  </aside>
+  <div class="flex-1 sm:ml-64">
+    <main class="p-6">
+      {% if page_title %}
+        <h1 class="text-2xl font-semibold mb-4">{{ page_title }}</h1>
+      {% endif %}
+      {% block body %}{% endblock %}
+    </main>
+  </div>
+</div>
+<script>
+const toggle = document.getElementById('mode-toggle');
+if(toggle){
+  toggle.onclick = () => document.body.classList.toggle('dark');
+}
+</script>
+{% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,69 +4,35 @@
 {% set page_title = "Home" %}
 
 {% block body %}
-<div class="pt-6 flex flex-col items-center gap-8 max-w-7xl mx-auto">
-
-  <!-- ════════════════════════════════
-       DRAG-AND-DROP + AJAX UPLOAD BOX
-       ════════════════════════════════ -->
-  <form id="resume-form"
-        class="w-full max-w-xl border-4 border-dashed border-gray-300
-               rounded-2xl flex flex-col items-center justify-center
-               py-16 bg-white/80 backdrop-blur transition-colors"
-        autocomplete="off">
-    <input id="resume-file"
-           type="file"
-           name="files"
-           accept=".pdf,.docx"
-           multiple
-           class="hidden">
-    <p class="text-lg text-gray-500 mb-4 pointer-events-none">
-      Drag &amp; drop a résumé PDF / DOCX here<br>
-      or click to browse
-    </p>
-    <button id="select-btn"
-            type="button"
-            class="px-4 py-2 rounded bg-blue-600 text-white">
-      Browse files
-    </button>
+<div class="max-w-5xl mx-auto flex flex-col gap-8">
+  <form id="resume-form" class="border-4 border-dashed border-indigo-300 rounded-3xl p-16 text-center bg-white/50 backdrop-blur-lg cursor-pointer transition-all" autocomplete="off">
+    <input id="resume-file" type="file" name="files" accept=".pdf,.docx" multiple class="hidden">
+    <div class="text-5xl text-indigo-400 mb-4"><i class="fa-solid fa-cloud-arrow-up"></i></div>
+    <p class="text-lg font-medium">Drop your résumé here<br>or click to browse files</p>
   </form>
 
-  <!-- upload progress feedback -->
   <div id="upload-progress" class="w-full max-w-xl"></div>
 
-  <!-- ════════════════════════════════
-       RECENT UPLOADS TABLE
-       ════════════════════════════════ -->
-  <section class="w-full max-w-5xl bg-white/70 backdrop-blur p-4 rounded-xl shadow">
-    <h2 class="text-lg font-medium mb-2">Recent uploads</h2>
-    <table id="uploads-table"
-           class="w-full text-sm border rounded-xl overflow-hidden shadow">
-      <thead>
-        <tr class="bg-gray-100 text-left">
-          <th class="px-4 py-2">Name</th>
-          <th class="px-2 py-2">Added</th>
-          <th class="px-2 py-2">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for r in resumes %}
-        <tr class="odd:bg-white even:bg-gray-50">
-          <td class="px-4 py-2">{{ r.name }}</td>
-          <td class="px-2 py-2">{{ r.added|default('—') }}</td>
-          <td class="px-2 py-2 space-x-3">
-            <a href="/resumes#{{ r.id }}" class="text-blue-600 hover:underline">edit</a>
-            <form action="/delete_resume" method="post" class="inline">
-              <input type="hidden" name="id" value="{{ r.id }}">
-              <button class="text-red-600 hover:underline"
-                      onclick="return confirm('Delete?')">delete</button>
-            </form>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+  <section>
+    <h2 class="text-xl font-semibold mb-2">Your Recent Uploads</h2>
+    <div class="flex overflow-x-auto gap-4 pb-4">
+      {% for r in resumes %}
+      <div class="card flex-shrink-0 w-64 animate-pop">
+        <div class="flex items-center justify-between mb-2">
+          <span class="font-medium">{{ r.name }}</span>
+          <span class="text-xs bg-indigo-100 text-indigo-600 rounded-full px-2 py-0.5">{{ r.added|default('—') }}</span>
+        </div>
+        <div class="flex gap-3 text-sm">
+          <a href="/resumes#{{ r.id }}" class="text-blue-600 flex items-center gap-1"><i class="fa-solid fa-pen"></i>Edit</a>
+          <form action="/delete_resume" method="post" class="inline">
+            <input type="hidden" name="id" value="{{ r.id }}">
+            <button class="text-red-600 flex items-center gap-1" onclick="return confirm('Delete?')"><i class="fa-solid fa-trash"></i>Delete</button>
+          </form>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
   </section>
-
 </div>
 {% endblock %}
 
@@ -74,75 +40,34 @@
 <script>
 const dropZone  = document.getElementById('resume-form');
 const fileInput = document.getElementById('resume-file');
-const browseBtn = document.getElementById('select-btn');
-
-
-/* click → open picker */
-browseBtn.onclick = () => fileInput.click();
-
-/* picker → send via fetch */
-fileInput.onchange = () => {
-  if (fileInput.files.length) uploadFiles(fileInput.files);
-};
-
-/* drag-and-drop visual cues */
-['dragenter','dragover'].forEach(evt =>
-  dropZone.addEventListener(evt, e=>{
-    e.preventDefault();
-    dropZone.classList.add('bg-blue-50');
-  })
-);
-['dragleave','drop'].forEach(evt =>
-  dropZone.addEventListener(evt, e=>{
-    e.preventDefault();
-    dropZone.classList.remove('bg-blue-50');
-  })
-);
-
-/* drop handler */
-dropZone.addEventListener('drop', e=>{
-  if (e.dataTransfer.files.length){
-    uploadFiles(e.dataTransfer.files);
-  }
-});
-
-/* core upload logic */
+dropZone.addEventListener('click', () => fileInput.click());
+fileInput.onchange = () => { if (fileInput.files.length) uploadFiles(fileInput.files); };
+['dragenter','dragover'].forEach(evt => dropZone.addEventListener(evt, e => { e.preventDefault(); dropZone.classList.add('drag-over'); }));
+['dragleave','drop'].forEach(evt => dropZone.addEventListener(evt, e => { e.preventDefault(); dropZone.classList.remove('drag-over'); }));
+dropZone.addEventListener('drop', e => { if (e.dataTransfer.files.length){ uploadFiles(e.dataTransfer.files); }});
 const progressBox = document.getElementById('upload-progress');
-
 function createBar(name){
   const wrapper = document.createElement('div');
   wrapper.className = 'my-2';
-  wrapper.innerHTML = `
-    <div class="text-sm mb-1">${name}</div>
-    <div class="w-full bg-gray-200 rounded"><div class="h-2 bg-blue-600 rounded" style="width:0%"></div></div>
-  `;
+  wrapper.innerHTML = `<div class="text-sm mb-1">${name}</div><div class="w-full bg-gray-200 rounded"><div class="h-2 bg-blue-600 rounded" style="width:0%"></div></div>`;
   progressBox.appendChild(wrapper);
   return wrapper.querySelector('.h-2');
 }
-
 function uploadFiles(files){
   const uploads = [];
   for(const file of files){
     const bar = createBar(file.name);
     uploads.push(uploadSingle(file, bar));
   }
-  Promise.allSettled(uploads).then(() => {
-    fileInput.value = '';
-    location.reload();
-  });
+  Promise.allSettled(uploads).then(() => { fileInput.value = ''; location.reload(); });
 }
-
 function uploadSingle(file, bar){
   return new Promise((resolve, reject) => {
     const fd = new FormData();
     fd.append('file', file);
     const xhr = new XMLHttpRequest();
     xhr.open('POST','/upload_resume');
-    xhr.upload.onprogress = e=>{
-      if(e.lengthComputable){
-        bar.style.width = (e.loaded/e.total*100)+'%';
-      }
-    };
+    xhr.upload.onprogress = e => { if(e.lengthComputable){ bar.style.width = (e.loaded/e.total*100)+'%'; } };
     xhr.onload = () => xhr.status>=200 && xhr.status<300 ? resolve() : reject();
     xhr.onerror = () => reject();
     xhr.send(fd);


### PR DESCRIPTION
## Summary
- redesign `_base.html` with a left sidebar navigation and dark mode toggle
- overhaul `/home` page with interactive drag & drop upload area and resume cards
- update CSS for new Manrope font, glass style cards and animations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492ec5b82c833080b8dfd4f8eb7310