### PR TITLE
Improve home layout and dark mode

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -15,6 +15,7 @@ header {
   backdrop-filter: blur(12px);
 }
 .card {
+  width: 100%;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(8px);
   border-radius: 0.75rem;
@@ -39,4 +40,30 @@ input, textarea, select {
 }
 .animate-pop {
   animation: pop 0.4s ease;
+}
+
+/* grid layout for recent uploads */
+.upload-grid {
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+@media (min-width: 640px) {
+  .upload-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (min-width: 768px) {
+  .upload-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+@media (min-width: 1024px) {
+  .upload-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+@media (min-width: 1280px) {
+  .upload-grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
 }

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -50,7 +50,10 @@
 <script>
 const toggle = document.getElementById('mode-toggle');
 if(toggle){
-  toggle.onclick = () => document.body.classList.toggle('dark');
+  toggle.onclick = () => {
+    document.body.classList.toggle('dark');
+    document.documentElement.classList.toggle('dark');
+  };
 }
 </script>
 {% block extra_js %}{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,9 +15,9 @@
 
   <section>
     <h2 class="text-xl font-semibold mb-2">Your Recent Uploads</h2>
-    <div class="flex overflow-x-auto gap-4 pb-4">
+    <div class="upload-grid gap-4 pb-4">
       {% for r in resumes %}
-      <div class="card flex-shrink-0 w-64 animate-pop">
+      <div class="card animate-pop">
         <div class="flex items-center justify-between mb-2">
           <span class="font-medium">{{ r.name }}</span>
           <span class="text-xs bg-indigo-100 text-indigo-600 rounded-full px-2 py-0.5">{{ r.added|default('—') }}</span>


### PR DESCRIPTION
## Summary
- show recent uploads in a responsive grid
- make cards full width
- toggle dark mode by applying the class to both `body` and `html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684930dc55c48330ac09758cdf15646b