### PR TITLE
Improve home layout and dark mode

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -40,3 +40,19 @@ input, textarea, select {
 .animate-pop {
   animation: pop 0.4s ease;
 }
+
+/* grid layout for recent uploads */
+.upload-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+  grid-auto-rows: auto;
+}
+
+body.dark aside {
+  background: rgba(30, 41, 59, 0.7);
+  color: #f1f5f9;
+}
+body.dark aside a,
+body.dark aside button {
+  color: inherit;
+}

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -50,7 +50,10 @@
 <script>
 const toggle = document.getElementById('mode-toggle');
 if(toggle){
-  toggle.onclick = () => document.body.classList.toggle('dark');
+  toggle.onclick = () => {
+    document.body.classList.toggle('dark');
+    document.documentElement.classList.toggle('dark');
+  };
 }
 </script>
 {% block extra_js %}{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
 
   <section>
     <h2 class="text-xl font-semibold mb-2">Your Recent Uploads</h2>
-    <div class="flex overflow-x-auto gap-4 pb-4">
+    <div class="upload-grid gap-4 pb-4">
       {% for r in resumes %}
       <div class="card flex-shrink-0 w-64 animate-pop">
         <div class="flex items-center justify-between mb-2">


### PR DESCRIPTION
## Summary
- use a CSS grid with automatic wrapping for uploads
- restore card width
- tweak sidebar colors in dark mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684930dc55c48330ac09758cdf15646b