### PR TITLE
Improve /home visuals and dark mode

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -10,6 +10,9 @@ body.dark {
   background: linear-gradient(135deg, #1e293b, #334155);
   color: #f1f5f9;
 }
+body.dark header {
+  background: rgba(30, 41, 59, 0.8);
+}
 header {
   background: rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(12px);
@@ -20,19 +23,39 @@ header {
   backdrop-filter: blur(8px);
   border-radius: 0.75rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  padding: 1.5rem;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  padding: 1.25rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 .dark .card {
   background: rgba(30, 41, 59, 0.7);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
+.dark .card:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.6);
+}
 input, textarea, select {
   border-color: #d1d5db;
+}
+body.dark input,
+body.dark textarea,
+body.dark select {
+  background-color: #1e293b;
+  color: #f1f5f9;
+  border-color: #475569;
 }
 #resume-form.drag-over {
   box-shadow: 0 0 0 4px rgba(59,130,246,0.4);
   transform: scale(1.02);
+}
+#resume-form i {
+  transition: transform 0.3s ease;
+}
+#resume-form:hover i {
+  transform: translateY(-4px);
 }
 @keyframes pop {
   from { opacity:0; transform: scale(0.95); }
@@ -45,8 +68,7 @@ input, textarea, select {
 /* grid layout for recent uploads */
 .upload-grid {
   display: grid;
-
-  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
   grid-auto-rows: auto;
 }
 
@@ -59,6 +81,9 @@ body.dark aside button {
   color: inherit;
 
   grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+body.dark a {
+  color: #93c5fd;
 }
 @media (min-width: 640px) {
   .upload-grid {

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -12,29 +12,29 @@
 </head>
 <body class="font-sans">
 <div class="flex min-h-screen">
-  <aside class="hidden sm:flex fixed inset-y-0 left-0 w-64 flex-col bg-white/70 backdrop-blur-lg shadow-xl p-4">
+  <aside class="hidden sm:flex fixed inset-y-0 left-0 w-64 flex-col bg-white/70 dark:bg-slate-800/70 backdrop-blur-lg shadow-xl p-4">
     <div class="flex items-center justify-between mb-6">
       <span class="text-lg font-semibold text-indigo-600">Recruitment Assistant</span>
       <button id="mode-toggle" class="text-gray-600"><i class="fa-solid fa-moon"></i></button>
     </div>
     <nav class="flex-1 space-y-2 text-sm">
-      <a href="/" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-house"></i>Home</a>
-      <a href="/resumes" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/resumes' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-file-lines"></i>Résumés</a>
-      <a href="/chat" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/chat' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-comments"></i>Chat</a>
-      <a href="/projects" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/projects' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-table-list"></i>Projects</a>
+      <a href="/" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-house"></i>Home</a>
+      <a href="/resumes" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/resumes' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-file-lines"></i>Résumés</a>
+      <a href="/chat" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/chat' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-comments"></i>Chat</a>
+      <a href="/projects" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/projects' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-table-list"></i>Projects</a>
       {% if user %}
-        <a href="/profile" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/profile' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-user"></i>Profile</a>
+        <a href="/profile" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/profile' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-user"></i>Profile</a>
       {% endif %}
       {% if user and user.role == 'owner' %}
-        <a href="/admin/users" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600' if active=='/admin/users' else 'hover:bg-indigo-50' }}"><i class="fa-solid fa-users"></i>Users</a>
+        <a href="/admin/users" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/admin/users' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-users"></i>Users</a>
       {% endif %}
     </nav>
     <div class="mt-auto pt-4 border-t flex items-center justify-between text-sm">
       {% if user %}
         <span class="truncate">{{ user.username }}</span>
-        <a href="/logout" class="text-gray-700 hover:text-red-600 flex items-center gap-1"><i class="fa-solid fa-right-from-bracket"></i>Logout</a>
+        <a href="/logout" class="text-gray-700 hover:text-red-600 dark:text-gray-300 dark:hover:text-red-400 flex items-center gap-1"><i class="fa-solid fa-right-from-bracket"></i>Logout</a>
       {% else %}
-        <a href="/login" class="text-gray-700 hover:text-indigo-600 flex items-center gap-1"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
+        <a href="/login" class="text-gray-700 hover:text-indigo-600 dark:text-gray-300 dark:hover:text-indigo-400 flex items-center gap-1"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       {% endif %}
     </div>
   </aside>
@@ -50,9 +50,15 @@
 <script>
 const toggle = document.getElementById('mode-toggle');
 if(toggle){
+  const enabled = localStorage.getItem('dark') === '1';
+  if(enabled){
+    document.body.classList.add('dark');
+    document.documentElement.classList.add('dark');
+  }
   toggle.onclick = () => {
-    document.body.classList.toggle('dark');
+    const active = document.body.classList.toggle('dark');
     document.documentElement.classList.toggle('dark');
+    localStorage.setItem('dark', active ? '1' : '0');
   };
 }
 </script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
 
 {% block body %}
 <div class="max-w-5xl mx-auto flex flex-col gap-8">
+  <p class="text-lg font-semibold">Welcome back, {{ user.username }}!</p>
   <form id="resume-form" class="border-4 border-dashed border-indigo-300 rounded-3xl p-16 text-center bg-white/50 backdrop-blur-lg cursor-pointer transition-all" autocomplete="off">
     <input id="resume-file" type="file" name="files" accept=".pdf,.docx" multiple class="hidden">
     <div class="text-5xl text-indigo-400 mb-4"><i class="fa-solid fa-cloud-arrow-up"></i></div>
@@ -18,15 +19,15 @@
     <div class="upload-grid gap-4 pb-4">
       {% for r in resumes %}
       <div class="card animate-pop">
-        <div class="flex items-center justify-between mb-2">
-          <span class="font-medium">{{ r.name }}</span>
-          <span class="text-xs bg-indigo-100 text-indigo-600 rounded-full px-2 py-0.5">{{ r.added|default('—') }}</span>
+        <div class="flex items-center justify-between mb-3">
+          <span class="font-semibold text-sm">{{ r.name }}</span>
+          <span class="text-xs text-gray-500">{{ r.added|default('—') }}</span>
         </div>
         <div class="flex gap-3 text-sm">
-          <a href="/resumes#{{ r.id }}" class="text-blue-600 flex items-center gap-1"><i class="fa-solid fa-pen"></i>Edit</a>
+          <a href="/resumes#{{ r.id }}" class="text-blue-600 hover:text-blue-800 transition-colors flex items-center gap-1"><i class="fa-solid fa-pen"></i>Edit</a>
           <form action="/delete_resume" method="post" class="inline">
             <input type="hidden" name="id" value="{{ r.id }}">
-            <button class="text-red-600 flex items-center gap-1" onclick="return confirm('Delete?')"><i class="fa-solid fa-trash"></i>Delete</button>
+            <button class="text-red-600 hover:text-red-800 transition-colors flex items-center gap-1" onclick="return confirm('Delete?')"><i class="fa-solid fa-trash"></i>Delete</button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- improve card layout, typography and hover effects on the home page
- add greeting message for the logged in user
- enable persistent dark mode and dark styling for the sidebar and links
- animate the upload icon and add grid tweaks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684935ff7f2083308b0892414fb94513