### PR TITLE
Improve recent uploads layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -68,8 +68,12 @@ body.dark select {
 /* grid layout for recent uploads */
 .upload-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
   grid-auto-rows: auto;
+}
+
+.upload-grid .card {
+  min-height: 6rem;
 }
 
 body.dark aside {
@@ -79,30 +83,7 @@ body.dark aside {
 body.dark aside a,
 body.dark aside button {
   color: inherit;
-
-  grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 body.dark a {
   color: #93c5fd;
-}
-@media (min-width: 640px) {
-  .upload-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-@media (min-width: 768px) {
-  .upload-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-@media (min-width: 1024px) {
-  .upload-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-}
-@media (min-width: 1280px) {
-  .upload-grid {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-  }
-
 }


### PR DESCRIPTION
## Summary
- tweak CSS for uploads card grid
- increase minimum card height and allow more columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684937b2c99483309911c710a4e28c01