### PR TITLE
Improve recent uploads layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -68,8 +68,12 @@ body.dark select {
 /* grid layout for recent uploads */
 .upload-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
   grid-auto-rows: auto;
+}
+
+.upload-grid .card {
+  min-height: 7rem;
 }
 
 body.dark aside {
@@ -79,30 +83,7 @@ body.dark aside {
 body.dark aside a,
 body.dark aside button {
   color: inherit;
-
-  grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 body.dark a {
   color: #93c5fd;
-}
-@media (min-width: 640px) {
-  .upload-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-@media (min-width: 768px) {
-  .upload-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-@media (min-width: 1024px) {
-  .upload-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-}
-@media (min-width: 1280px) {
-  .upload-grid {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-  }
-
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
 
   <section>
     <h2 class="text-xl font-semibold mb-2">Your Recent Uploads</h2>
-    <div class="upload-grid gap-4 pb-4">
+    <div class="upload-grid grid gap-4 pb-4">
       {% for r in resumes %}
       <div class="card animate-pop">
         <div class="flex items-center justify-between mb-3">


### PR DESCRIPTION
## Summary
- tweak grid CSS for recent uploads
- mark uploads container as grid

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684937b2c99483309911c710a4e28c01