### PR TITLE
Improve home page layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -51,11 +51,29 @@ body.dark select {
   box-shadow: 0 0 0 4px rgba(59,130,246,0.4);
   transform: scale(1.02);
 }
+#resume-form {
+  position: relative;
+}
+#resume-form::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: 0.25rem;
+  border: 2px dashed rgba(99,102,241,0.3);
+  border-radius: 1.5rem;
+}
 #resume-form i {
   transition: transform 0.3s ease;
 }
 #resume-form:hover i {
   transform: translateY(-4px);
+}
+@keyframes bounce {
+  0%,100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+#resume-form:hover .cloud-icon {
+  animation: bounce 0.6s ease;
 }
 @keyframes pop {
   from { opacity:0; transform: scale(0.95); }
@@ -68,9 +86,7 @@ body.dark select {
 /* grid layout for recent uploads */
 .upload-grid {
   display: grid;
-
-  grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
-
+  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
   grid-auto-rows: auto;
 }
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -18,15 +18,15 @@
       <button id="mode-toggle" class="text-gray-600"><i class="fa-solid fa-moon"></i></button>
     </div>
     <nav class="flex-1 space-y-2 text-sm">
-      <a href="/" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-house"></i>Home</a>
-      <a href="/resumes" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/resumes' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-file-lines"></i>Résumés</a>
-      <a href="/chat" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/chat' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-comments"></i>Chat</a>
-      <a href="/projects" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/projects' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-table-list"></i>Projects</a>
+      <a href="/" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-gradient-to-r from-indigo-50 to-indigo-100 text-indigo-600 dark:from-slate-700 dark:to-slate-600 dark:text-indigo-300' if active=='/' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-house"></i>Home</a>
+      <a href="/resumes" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-gradient-to-r from-indigo-50 to-indigo-100 text-indigo-600 dark:from-slate-700 dark:to-slate-600 dark:text-indigo-300' if active=='/resumes' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-file-lines"></i>Résumés</a>
+      <a href="/chat" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-gradient-to-r from-indigo-50 to-indigo-100 text-indigo-600 dark:from-slate-700 dark:to-slate-600 dark:text-indigo-300' if active=='/chat' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-comments"></i>Chat</a>
+      <a href="/projects" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-gradient-to-r from-indigo-50 to-indigo-100 text-indigo-600 dark:from-slate-700 dark:to-slate-600 dark:text-indigo-300' if active=='/projects' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-table-list"></i>Projects</a>
       {% if user %}
-        <a href="/profile" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/profile' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-user"></i>Profile</a>
+        <a href="/profile" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-gradient-to-r from-indigo-50 to-indigo-100 text-indigo-600 dark:from-slate-700 dark:to-slate-600 dark:text-indigo-300' if active=='/profile' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-user"></i>Profile</a>
       {% endif %}
       {% if user and user.role == 'owner' %}
-        <a href="/admin/users" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-indigo-50 text-indigo-600 dark:bg-slate-700 dark:text-indigo-300' if active=='/admin/users' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-users"></i>Users</a>
+        <a href="/admin/users" class="flex items-center gap-2 rounded px-2 py-1 {{ 'bg-gradient-to-r from-indigo-50 to-indigo-100 text-indigo-600 dark:from-slate-700 dark:to-slate-600 dark:text-indigo-300' if active=='/admin/users' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-users"></i>Users</a>
       {% endif %}
     </nav>
     <div class="mt-auto pt-4 border-t flex items-center justify-between text-sm">
@@ -41,7 +41,7 @@
   <div class="flex-1 sm:ml-64">
     <main class="p-6">
       {% if page_title %}
-        <h1 class="text-2xl font-semibold mb-4">{{ page_title }}</h1>
+        <h1 class="text-3xl font-bold mb-6">{{ page_title }}</h1>
       {% endif %}
       {% block body %}{% endblock %}
     </main>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,24 +6,23 @@
 {% block body %}
 <div class="max-w-5xl mx-auto flex flex-col gap-8">
   <p class="text-lg font-semibold">Welcome back, {{ user.username }}!</p>
-  <form id="resume-form" class="border-4 border-dashed border-indigo-300 rounded-3xl p-16 text-center bg-white/50 backdrop-blur-lg cursor-pointer transition-all" autocomplete="off">
+  <form id="resume-form" class="border-4 border-dashed border-indigo-300 rounded-3xl p-16 text-center bg-white/50 backdrop-blur-lg cursor-pointer transition-all relative" autocomplete="off">
     <input id="resume-file" type="file" name="files" accept=".pdf,.docx" multiple class="hidden">
-    <div class="text-5xl text-indigo-400 mb-4"><i class="fa-solid fa-cloud-arrow-up"></i></div>
+    <div class="text-5xl text-indigo-400 mb-4 cloud-icon"><i class="fa-solid fa-cloud-arrow-up"></i></div>
     <p class="text-lg font-medium">Drop your résumé here<br>or click to browse files</p>
+    <div id="upload-preview" class="mt-6 space-y-2 text-left"></div>
   </form>
 
-  <div id="upload-progress" class="w-full max-w-xl"></div>
-
   <section>
-    <h2 class="text-xl font-semibold mb-2">Your Recent Uploads</h2>
+    <h2 class="text-xl font-bold mb-4">Your Recent Uploads</h2>
     <div class="upload-grid grid gap-4 pb-4">
       {% for r in resumes %}
-      <div class="card animate-pop">
-        <div class="flex items-center justify-between mb-3">
-          <span class="font-semibold text-sm">{{ r.name }}</span>
+      <div class="card animate-pop flex flex-col">
+        <div class="flex items-start justify-between mb-2">
+          <span class="font-bold text-base">{{ r.name }}</span>
           <span class="text-xs text-gray-500">{{ r.added|default('—') }}</span>
         </div>
-        <div class="flex gap-3 text-sm">
+        <div class="mt-auto flex justify-end gap-3 text-sm opacity-90 hover:opacity-100">
           <a href="/resumes#{{ r.id }}" class="text-blue-600 hover:text-blue-800 transition-colors flex items-center gap-1"><i class="fa-solid fa-pen"></i>Edit</a>
           <form action="/delete_resume" method="post" class="inline">
             <input type="hidden" name="id" value="{{ r.id }}">
@@ -46,7 +45,7 @@ fileInput.onchange = () => { if (fileInput.files.length) uploadFiles(fileInput.f
 ['dragenter','dragover'].forEach(evt => dropZone.addEventListener(evt, e => { e.preventDefault(); dropZone.classList.add('drag-over'); }));
 ['dragleave','drop'].forEach(evt => dropZone.addEventListener(evt, e => { e.preventDefault(); dropZone.classList.remove('drag-over'); }));
 dropZone.addEventListener('drop', e => { if (e.dataTransfer.files.length){ uploadFiles(e.dataTransfer.files); }});
-const progressBox = document.getElementById('upload-progress');
+const progressBox = document.getElementById('upload-preview');
 function createBar(name){
   const wrapper = document.createElement('div');
   wrapper.className = 'my-2';


### PR DESCRIPTION
## Summary
- refine resume cards, improve nav highlight and typography
- revamp drop zone with inner shadow and bounce animation
- show upload previews inside drop zone
- tweak upload grid CSS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68493b2a99448330bb701fdb135ce56e