### PR TITLE
Improve recent uploads layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -84,15 +84,15 @@ body.dark select {
 }
 
 /* grid layout for recent uploads */
+
 .upload-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(15.5rem, 1fr));
   grid-auto-rows: auto;
 }
 
 .upload-grid .card {
-  min-height: 7rem;
-
+  height: 15.5rem;
 }
 
 body.dark aside {

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,8 +15,8 @@
 
   <section>
     <h2 class="text-xl font-bold mb-4">Your Recent Uploads</h2>
-    <div class="upload-grid grid gap-4 pb-4">
-      {% for r in resumes %}
+    <div class="upload-grid grid gap-4 pb-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {% for r in resumes[:16] %}
       <div class="card animate-pop flex flex-col">
         <div class="flex items-start justify-between mb-2">
           <span class="font-bold text-base">{{ r.name }}</span>


### PR DESCRIPTION
## Summary
- keep the recent uploads grid responsive
- limit shown uploads to 16 items
- make each card square using custom CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493ea4edb0833089c9a406ec1b1a6f