### PR TITLE
Improve recent upload card UX

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -18,16 +18,17 @@ header {
   backdrop-filter: blur(12px);
 }
 .card {
+  position: relative;
   width: 100%;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(8px);
   border-radius: 0.75rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   padding: 1.25rem;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease-in, box-shadow 0.2s ease-in;
 }
 .card:hover {
-  transform: translateY(-2px);
+  transform: translateY(-4px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 .dark .card {
@@ -93,6 +94,19 @@ body.dark select {
 
 .upload-grid .card {
   height: 15.5rem;
+}
+
+.card .actions {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.2s ease-in, visibility 0.2s ease-in;
+}
+
+.card:hover .actions {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }
 
 body.dark aside {

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,11 +22,11 @@
           <span class="font-bold text-base">{{ r.name }}</span>
           <span class="text-xs text-gray-500">{{ r.added|default('—') }}</span>
         </div>
-        <div class="mt-auto flex justify-end gap-3 text-sm opacity-90 hover:opacity-100">
+        <div class="actions mt-auto flex justify-end gap-3 text-sm">
           <a href="/resumes#{{ r.id }}" class="text-blue-600 hover:text-blue-800 transition-colors flex items-center gap-1"><i class="fa-solid fa-pen"></i>Edit</a>
-          <form action="/delete_resume" method="post" class="inline">
+          <form action="/delete_resume" method="post" class="delete-form inline">
             <input type="hidden" name="id" value="{{ r.id }}">
-            <button class="text-red-600 hover:text-red-800 transition-colors flex items-center gap-1" onclick="return confirm('Delete?')"><i class="fa-solid fa-trash"></i>Delete</button>
+            <button class="text-red-600 hover:text-red-800 transition-colors flex items-center gap-1"><i class="fa-solid fa-trash"></i>Delete</button>
           </form>
         </div>
       </div>
@@ -73,5 +73,16 @@ function uploadSingle(file, bar){
     xhr.send(fd);
   });
 }
+
+// handle inline résumé deletion without leaving the page
+document.querySelectorAll('.delete-form').forEach(form => {
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    if(!confirm('Delete?')) return;
+    const fd = new FormData(form);
+    const resp = await fetch('/delete_resume', {method:'POST', body: fd});
+    if(resp.ok) form.closest('.card').remove();
+  });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- tweak card animation and show controls on hover
- hide action buttons until card hover
- add inline resume deletion via JS
- adjust CSS to hide actions properly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684941468dbc8330a76701aa3cb09eaa