### PR TITLE
Add hover reveal for upload cards

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -98,18 +98,17 @@ body.dark select {
 
 .card .actions {
   opacity: 0;
-
   visibility: hidden;
   pointer-events: none;
-  transition: opacity 0.2s ease-in, visibility 0.2s ease-in;
+  transition: opacity 0.2s ease-in, transform 0.2s ease-in, visibility 0.2s ease-in;
+  transform: translateY(4px);
 }
 
 .card:hover .actions {
   opacity: 1;
-
   visibility: visible;
   pointer-events: auto;
-
+  transform: translateY(0);
 }
 
 body.dark aside {

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
           <span class="text-xs text-gray-500">{{ r.added|default('—') }}</span>
         </div>
         <div class="actions mt-auto flex justify-end gap-3 text-sm">
-          <a href="/resumes#{{ r.id }}" class="text-blue-600 hover:text-blue-800 transition-colors flex items-center gap-1"><i class="fa-solid fa-pen"></i>Edit</a>
+          <a href="/edit_resume?id={{ r.id }}" class="text-blue-600 hover:text-blue-800 transition-colors flex items-center gap-1"><i class="fa-solid fa-pen"></i>Edit</a>
           <form action="/delete_resume" method="post" class="delete-form inline">
             <input type="hidden" name="id" value="{{ r.id }}">
             <button class="text-red-600 hover:text-red-800 transition-colors flex items-center gap-1"><i class="fa-solid fa-trash"></i>Delete</button>


### PR DESCRIPTION
## Summary
- make edit link on front page go directly to edit page
- fade edit/delete buttons in on hover
- lift card on hover with smooth reveal animation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849442811e8833083b2d4e01e90a620