### PR TITLE
Enhance chat UI with avatars and timestamps

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -24,27 +24,43 @@
 
   {# ── main chat column ───────────────────────────────────────── #}
   <main class="flex-1 flex flex-col h-full">
-    <div id="chat-box" class="flex-1 overflow-auto p-6 space-y-3">
+    <div id="chat-box" class="flex-1 overflow-auto p-6 space-y-4">
       {% for msg in history %}
-      <div class="max-w-prose {{ 'ml-auto text-right' if msg.role=='user' else '' }}">
-        <div class="rounded-xl px-4 py-2
-                    {{ 'bg-blue-100' if msg.role=='user' else 'bg-rose-100' }}
-                    whitespace-pre-wrap">
-          <strong>{{ 'You' if msg.role=='user' else 'Assistant' }}:</strong>
-          {{ msg.content | safe }}
+      {% if msg.role == 'assistant' %}
+      <div class="flex items-start gap-2 max-w-prose">
+        <div class="w-7 h-7 rounded-full bg-blue-600 text-white flex items-center justify-center">
+          <i class="fa-solid fa-robot text-xs"></i>
+        </div>
+        <div>
+          <div class="text-xs font-semibold text-gray-600">Assistant</div>
+          <div class="rounded-xl px-4 py-2 bg-sky-50 whitespace-pre-wrap">
+            {{ msg.content | safe }}
+          </div>
+          {% if msg.time %}<div class="text-xs text-gray-500 mt-1">{{ msg.time }}</div>{% endif %}
         </div>
       </div>
-      {% endfor %}
+      {% else %}
+      <div class="max-w-prose ml-auto text-right">
+        <div class="rounded-xl px-4 py-2 bg-blue-100 whitespace-pre-wrap">
+          {{ msg.content | safe }}
+        </div>
+        {% if msg.time %}<div class="text-xs text-gray-500 mt-1">{{ msg.time }}</div>{% endif %}
       </div>
+      {% endif %}
+      {% endfor %}
+    </div>
 
       {# quick prompts row #}
-      <div id="quick-prompts" class="border-t bg-white/70 dark:bg-slate-700/70 backdrop-blur p-4 flex flex-wrap gap-2">
-        {% for pr in quick_prompts %}
-
-        <button type="button" class="quick-prompt chip cursor-pointer" data-text="{{ pr.text }}">
-          {{ pr.title }}
-
-        </button>
+      <div id="quick-prompts" class="border-t bg-white/70 dark:bg-slate-700/70 backdrop-blur p-4 space-y-2 text-sm">
+        {% for grp, items in quick_prompts|groupby('group') %}
+        <div class="flex items-center flex-wrap gap-2">
+          <span class="font-medium mr-1">{{ grp }}</span>
+          {% for pr in items %}
+          <button type="button" class="quick-prompt chip cursor-pointer" data-text="{{ pr.text }}" title="{{ pr.text }}">
+            <i class="{{ pr.icon }}"></i>{{ pr.title }}
+          </button>
+          {% endfor %}
+        </div>
         {% endfor %}
       </div>
 
@@ -59,15 +75,16 @@
       </div>
 
       {# input row #}
-      <div class="border-t bg-white/70 dark:bg-slate-700/70 backdrop-blur p-4 flex items-center gap-2">
+      <div class="border-t bg-white/60 dark:bg-slate-700/60 backdrop-blur shadow p-4 flex items-center gap-2">
       <button id="attach-btn" title="Upload project"
-              class="p-2 rounded bg-gray-200 dark:bg-slate-600 dark:text-white">📎</button>
+              class="p-2 rounded text-gray-600 hover:bg-gray-200 dark:text-white dark:hover:bg-slate-600">
+        <i class="fa-solid fa-paperclip"></i>
+      </button>
       <input id="project-file" type="file" accept=".pdf,.docx" class="hidden">
-      <input id="chat-input" type="text"
-             placeholder="Type a message…"
-             class="flex-1 border px-3 py-2 rounded">
+      <textarea id="chat-input" rows="1" placeholder="Type a message…"
+                class="flex-1 border px-3 py-2 rounded resize-none"></textarea>
       <button id="send-btn"
-              class="bg-blue-600 text-white px-4 py-2 rounded">
+              class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">
         Send
       </button>
     </div>
@@ -80,6 +97,7 @@
 const qs = s => document.querySelector(s);
 const modeSel = () => qs('#chat-mode');
 let typingDiv = null;
+const timeStr = t => new Date(t).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
 
 // ── helper: currently-selected candidate IDs ────────────────
 function selected() {
@@ -88,16 +106,28 @@ function selected() {
 }
 
 // ── helper: append chat bubble and auto-scroll ──────────────
-function addBubble(role, html) {
+function addBubble(role, html, time) {
   const align = role === 'user' ? 'ml-auto text-right' : '';
-  const bg    = role === 'user' ? 'bg-blue-100'          : 'bg-rose-100';
-  qs('#chat-box').insertAdjacentHTML('beforeend',
-    `<div class="max-w-prose ${align}">
-       <div class="rounded-xl px-4 py-2 ${bg} whitespace-pre-wrap">
-         <strong>${role === 'user' ? 'You' : 'Assistant'}:</strong> ${html}
-         ${role === 'assist' ? '<div class="text-xs mt-1"><span class="feedback">👍</span> <span class="feedback">👎</span></div>' : ''}
-       </div>
-     </div>`);
+  const bg    = role === 'user' ? 'bg-blue-100' : 'bg-sky-50';
+  let block;
+  if (role === 'assist') {
+    block = `<div class="flex items-start gap-2 max-w-prose">
+                <div class="w-7 h-7 rounded-full bg-blue-600 text-white flex items-center justify-center">
+                  <i class="fa-solid fa-robot text-xs"></i>
+                </div>
+                <div>
+                  <div class="text-xs font-semibold text-gray-600">Assistant</div>
+                  <div class="rounded-xl px-4 py-2 ${bg} whitespace-pre-wrap">${html}</div>
+                  ${time ? `<div class=\"text-xs text-gray-500 mt-1\">${time}</div>` : ''}
+                </div>
+              </div>`;
+  } else {
+    block = `<div class="max-w-prose ${align}">
+               <div class="rounded-xl px-4 py-2 ${bg} whitespace-pre-wrap">${html}</div>
+               ${time ? `<div class=\"text-xs text-gray-500 mt-1\">${time}</div>` : ''}
+             </div>`;
+  }
+  qs('#chat-box').insertAdjacentHTML('beforeend', block);
   qs('#chat-box').scrollTop = qs('#chat-box').scrollHeight;
 }
 
@@ -106,7 +136,7 @@ function showTyping() {
   typingDiv = document.createElement('div');
   typingDiv.className = 'max-w-prose';
   typingDiv.innerHTML = `
-    <div class="rounded-xl px-4 py-2 bg-rose-100">
+    <div class="rounded-xl px-4 py-2 bg-sky-50">
       <div class="typing-indicator"><span></span><span></span><span></span></div>
     </div>`;
   qs('#chat-box').appendChild(typingDiv);
@@ -128,7 +158,8 @@ async function sendPrompt(raw) {
     if (title === null) return;
     finalText = raw.replace('[Insert job title]', title);
   }
-  addBubble('user', finalText);
+  const t = timeStr(Date.now());
+  addBubble('user', finalText, t);
   showTyping();
   const res = await fetch('/chat', {
     method: 'POST',
@@ -137,7 +168,7 @@ async function sendPrompt(raw) {
   });
   const data = await res.json();
   hideTyping();
-  addBubble('assist', data.reply);
+  addBubble('assist', data.reply, timeStr(data.time || Date.now()));
 }
 
 // ── sidebar filter ──────────────────────────────────────────
@@ -153,7 +184,8 @@ qs('#send-btn').onclick = async () => {
   const txt = qs('#chat-input').value.trim();
   if (!txt) return;
   qs('#chat-input').value = '';
-  addBubble('user', txt);
+  const ut = timeStr(Date.now());
+  addBubble('user', txt, ut);
 
   showTyping();
 
@@ -164,8 +196,20 @@ qs('#send-btn').onclick = async () => {
   });
   const data = await res.json();
   hideTyping();
-  addBubble('assist', data.reply);
+  addBubble('assist', data.reply, timeStr(data.time || Date.now()));
 };
+
+// enter to send, shift+enter newline
+qs('#chat-input').addEventListener('keydown', e => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    qs('#send-btn').click();
+  }
+});
+qs('#chat-input').addEventListener('input', e => {
+  e.target.style.height = 'auto';
+  e.target.style.height = e.target.scrollHeight + 'px';
+});
 
 // ── send project file ───────────────────────────────────────
 qs('#attach-btn').onclick = () => qs('#project-file').click();
@@ -175,11 +219,11 @@ qs('#project-file').onchange = async e => {
   const fd = new FormData();
   fd.append('file', f);
   selected().forEach(id => fd.append('candidate_ids', id));
-  addBubble('user', '[uploaded project]');
+  addBubble('user', '[uploaded project]', timeStr(Date.now()));
   showTyping();
   const html = await (await fetch('/match_project', {method: 'POST', body: fd})).text();
   hideTyping();
-  addBubble('assist', html);
+  addBubble('assist', html, timeStr(Date.now()));
   e.target.value = '';
 };
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,7 +49,8 @@ async def test_upload_resume_json(authed):
 async def test_chat_json(authed):
     resp = await main.chat(DummyRequest("/chat"), chat_data=main.ChatRequest(text="hello", candidate_ids=[]))
     assert resp.status_code == 200
-    assert resp.body == b'{"reply":"hi"}' or resp.body == b'{"reply": "hi"}'
+    assert b'"reply":' in resp.body
+    assert b'"time":' in resp.body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- store message timestamps and include them in chat JSON responses
- group quick prompts with icons
- add assistant avatar, timestamps, and better input styling in `/chat`
- support Enter-to-send shortcuts and dynamic textarea growth
- update tests for new response format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849675a270c833089222aef76488b15