### PR TITLE
Improve candidate selection in chat

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -74,7 +74,15 @@ QUICK_PROMPTS = [
 
 @router.get("/chat", response_class=HTMLResponse)
 async def chat_interface(request: Request, user=Depends(main.require_login)):
-    candidates = [{"id": r["resume_id"], "name": r["name"]} for r in await main.resumes_all()]
+    candidates = [
+        {
+            "id": r.get("resume_id"),
+            "name": r.get("name"),
+            "location": r.get("location", ""),
+            "skills": r.get("skills", [])[:3],
+        }
+        for r in await main.resumes_all()
+    ]
     session_user = await main.get_current_user(request.cookies.get(main.COOKIE_NAME))
     user_id = session_user["username"] if session_user else "anon"
     doc = await main.chat_find_one({"user_id": user_id}) or {}

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -7,16 +7,24 @@
 <div class="flex h-[calc(100vh-4rem)] bg-gradient-to-br from-gray-50 to-gray-100">
 
   {# ── sidebar ────────────────────────────────────────────────── #}
-  <aside class="w-64 border-r border-gray-200 bg-white/70 backdrop-blur p-4 overflow-auto">
+  <aside class="w-64 border-r border-gray-200 bg-white/70 dark:bg-slate-800/70 backdrop-blur p-4 overflow-auto">
     <h2 class="font-semibold mb-2">Candidates</h2>
     <input id="filter" type="text"
-           placeholder="filter…" 
+           placeholder="filter…"
            class="mb-3 w-full border px-2 py-1 rounded" />
-    <div id="cand-list" class="space-y-1 text-sm">
+    <div id="cand-list" class="space-y-2 text-sm">
       {% for c in candidates %}
-      <label class="flex items-center space-x-2">
-        <input type="checkbox" value="{{ c.id }}" class="candidate-box">
-        <span>{{ c.name }}</span>
+      <label class="candidate-item flex items-center gap-2 p-2 rounded-lg border cursor-pointer hover:bg-gray-100 dark:hover:bg-slate-700">
+        <input type="checkbox" value="{{ c.id }}" class="candidate-box peer hidden">
+        <div class="w-8 h-8 rounded-full bg-indigo-500 text-white flex items-center justify-center text-xs avatar">{{ c.name[:1] }}</div>
+        <div class="flex-1">
+          <div class="font-medium">{{ c.name }}</div>
+          <div class="text-xs mt-1 space-x-1">
+            {% if c.location %}<span class="chip">{{ c.location }}</span>{% endif %}
+            {% for s in c.skills %}<span class="chip">{{ s }}</span>{% endfor %}
+          </div>
+        </div>
+        <button type="button" class="switch-btn text-blue-600 text-xs hidden peer-checked:inline">switch</button>
       </label>
       {% endfor %}
     </div>
@@ -33,7 +41,7 @@
         </div>
         <div>
           <div class="text-xs font-semibold text-gray-600">Assistant</div>
-          <div class="rounded-xl px-4 py-2 bg-sky-50 whitespace-pre-wrap">
+          <div class="rounded-xl px-4 py-2 bg-sky-50 dark:bg-slate-700 whitespace-pre-wrap">
             {{ msg.content | safe }}
           </div>
           {% if msg.time %}<div class="text-xs text-gray-500 mt-1">{{ msg.time }}</div>{% endif %}
@@ -41,7 +49,7 @@
       </div>
       {% else %}
       <div class="max-w-prose ml-auto text-right">
-        <div class="rounded-xl px-4 py-2 bg-blue-100 whitespace-pre-wrap">
+        <div class="rounded-xl px-4 py-2 bg-blue-100 dark:bg-slate-600 whitespace-pre-wrap">
           {{ msg.content | safe }}
         </div>
         {% if msg.time %}<div class="text-xs text-gray-500 mt-1">{{ msg.time }}</div>{% endif %}
@@ -108,7 +116,9 @@ function selected() {
 // ── helper: append chat bubble and auto-scroll ──────────────
 function addBubble(role, html, time) {
   const align = role === 'user' ? 'ml-auto text-right' : '';
-  const bg    = role === 'user' ? 'bg-blue-100' : 'bg-sky-50';
+  const bg    = role === 'user'
+               ? 'bg-blue-100 dark:bg-slate-600'
+               : 'bg-sky-50 dark:bg-slate-700';
   let block;
   if (role === 'assist') {
     block = `<div class="flex items-start gap-2 max-w-prose">
@@ -136,7 +146,7 @@ function showTyping() {
   typingDiv = document.createElement('div');
   typingDiv.className = 'max-w-prose';
   typingDiv.innerHTML = `
-    <div class="rounded-xl px-4 py-2 bg-sky-50">
+    <div class="rounded-xl px-4 py-2 bg-sky-50 dark:bg-slate-700">
       <div class="typing-indicator"><span></span><span></span><span></span></div>
     </div>`;
   qs('#chat-box').appendChild(typingDiv);
@@ -178,6 +188,29 @@ qs('#filter').oninput = e => {
     lb.style.display = lb.innerText.toLowerCase().includes(v) ? '' : 'none';
   });
 };
+
+// highlight selected candidates
+document.querySelectorAll('.candidate-box').forEach(cb => {
+  cb.addEventListener('change', e => {
+    const lbl = e.target.closest('label');
+    if (e.target.checked) lbl.classList.add('ring', 'ring-indigo-400', 'bg-indigo-50', 'dark:bg-slate-700');
+    else lbl.classList.remove('ring', 'ring-indigo-400', 'bg-indigo-50', 'dark:bg-slate-700');
+  });
+});
+
+// quick switch buttons
+document.querySelectorAll('.switch-btn').forEach(btn => {
+  btn.onclick = e => {
+    const parent = e.target.closest('label');
+    document.querySelectorAll('.candidate-box').forEach(cb => {
+      cb.checked = false;
+      cb.dispatchEvent(new Event('change'));
+    });
+    const cb = parent.querySelector('.candidate-box');
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+  };
+});
 
 // ── send text message ───────────────────────────────────────
 qs('#send-btn').onclick = async () => {


### PR DESCRIPTION
## Summary
- improve chat page candidate sidebar
- highlight selected candidates and allow switching mid-chat
- adjust message bubble styling for dark mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684969ebc51083308c0ba302bb61433d