### PR TITLE
Improve chat UI readability and style

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -192,3 +192,36 @@ body.dark a {
 }
 .feedback:hover { opacity: 1; }
 .dark .feedback { color: #f1f5f9; }
+
+/* chat bubbles text color */
+.chat-bubble {
+  color: #374151;
+}
+body.dark .chat-bubble {
+  color: #f1f5f9;
+}
+
+/* chat mode buttons */
+.mode-btn {
+  border: 1px solid #d1d5db;
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.875rem;
+  background: #fff;
+  transition: background 0.2s ease;
+}
+.mode-btn:hover { background: #f1f5f9; }
+.mode-btn.active {
+  background: #2563eb;
+  color: #fff;
+}
+body.dark .mode-btn {
+  border-color: #475569;
+  background: #1e293b;
+  color: #f1f5f9;
+}
+body.dark .mode-btn:hover { background: #334155; }
+body.dark .mode-btn.active {
+  background: #3b82f6;
+  color: #fff;
+}

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -7,7 +7,7 @@
 <div class="flex h-[calc(100vh-4rem)] bg-gradient-to-br from-gray-50 to-gray-100">
 
   {# ── sidebar ────────────────────────────────────────────────── #}
-  <aside class="w-64 border-r border-gray-200 bg-white/70 dark:bg-slate-800/70 backdrop-blur p-4 overflow-auto">
+  <aside class="w-64 border-r border-gray-200 p-4 overflow-auto bg-transparent">
     <h2 class="font-semibold mb-2">Candidates</h2>
     <input id="filter" type="text"
            placeholder="filter…"
@@ -41,7 +41,7 @@
         </div>
         <div>
           <div class="text-xs font-semibold text-gray-600">Assistant</div>
-          <div class="rounded-xl px-4 py-2 bg-sky-50 dark:bg-slate-700 whitespace-pre-wrap">
+          <div class="chat-bubble rounded-xl px-4 py-2 bg-sky-50 dark:bg-slate-700 whitespace-pre-wrap">
             {{ msg.content | safe }}
           </div>
           {% if msg.time %}<div class="text-xs text-gray-500 mt-1">{{ msg.time }}</div>{% endif %}
@@ -49,7 +49,7 @@
       </div>
       {% else %}
       <div class="max-w-prose ml-auto text-right">
-        <div class="rounded-xl px-4 py-2 bg-blue-100 dark:bg-slate-600 whitespace-pre-wrap">
+        <div class="chat-bubble rounded-xl px-4 py-2 bg-blue-100 dark:bg-slate-600 whitespace-pre-wrap">
           {{ msg.content | safe }}
         </div>
         {% if msg.time %}<div class="text-xs text-gray-500 mt-1">{{ msg.time }}</div>{% endif %}
@@ -74,12 +74,13 @@
 
       {# chat mode toggle #}
       <div class="border-t bg-white/70 dark:bg-slate-700/70 backdrop-blur p-4 flex items-center gap-2 text-sm">
-        <label for="chat-mode" class="font-medium">Chat mode:</label>
-        <select id="chat-mode" class="border rounded px-2 py-1">
-          <option value="general">General AI</option>
-          <option value="ats">ATS Assistant</option>
-          <option value="role">Role-based Guidance</option>
-        </select>
+        <span class="font-medium">Chat mode:</span>
+        <input type="hidden" id="chat-mode" value="general">
+        <div id="chat-mode-group" class="flex gap-2">
+          <button type="button" data-mode="general" class="mode-btn active">General AI</button>
+          <button type="button" data-mode="ats" class="mode-btn">ATS Assistant</button>
+          <button type="button" data-mode="role" class="mode-btn">Role-based Guidance</button>
+        </div>
       </div>
 
       {# input row #}
@@ -127,13 +128,13 @@ function addBubble(role, html, time) {
                 </div>
                 <div>
                   <div class="text-xs font-semibold text-gray-600">Assistant</div>
-                  <div class="rounded-xl px-4 py-2 ${bg} whitespace-pre-wrap">${html}</div>
+                  <div class="chat-bubble rounded-xl px-4 py-2 ${bg} whitespace-pre-wrap">${html}</div>
                   ${time ? `<div class=\"text-xs text-gray-500 mt-1\">${time}</div>` : ''}
                 </div>
               </div>`;
   } else {
     block = `<div class="max-w-prose ${align}">
-               <div class="rounded-xl px-4 py-2 ${bg} whitespace-pre-wrap">${html}</div>
+               <div class="chat-bubble rounded-xl px-4 py-2 ${bg} whitespace-pre-wrap">${html}</div>
                ${time ? `<div class=\"text-xs text-gray-500 mt-1\">${time}</div>` : ''}
              </div>`;
   }
@@ -146,7 +147,7 @@ function showTyping() {
   typingDiv = document.createElement('div');
   typingDiv.className = 'max-w-prose';
   typingDiv.innerHTML = `
-    <div class="rounded-xl px-4 py-2 bg-sky-50 dark:bg-slate-700">
+    <div class="chat-bubble rounded-xl px-4 py-2 bg-sky-50 dark:bg-slate-700">
       <div class="typing-indicator"><span></span><span></span><span></span></div>
     </div>`;
   qs('#chat-box').appendChild(typingDiv);
@@ -209,6 +210,15 @@ document.querySelectorAll('.switch-btn').forEach(btn => {
     const cb = parent.querySelector('.candidate-box');
     cb.checked = true;
     cb.dispatchEvent(new Event('change'));
+  };
+});
+
+// chat mode buttons
+document.querySelectorAll('#chat-mode-group .mode-btn').forEach(btn => {
+  btn.onclick = () => {
+    document.querySelectorAll('#chat-mode-group .mode-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    modeSel().value = btn.dataset.mode;
   };
 });
 


### PR DESCRIPTION
## Summary
- tweak candidate panel background
- lighten chat bubble text color in light mode
- add modern button UI for chat modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68496f6121748330aea3db85a35deb3a