### PR TITLE
Improve /chat page readability

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -36,7 +36,7 @@
       {% for msg in history %}
       {% if msg.role == 'assistant' %}
       <div class="message flex items-start gap-2 max-w-prose">
-        <div class="w-7 h-7 rounded-full bg-blue-600 text-white flex items-center justify-center">
+        <div class="w-7 h-7 rounded-full bg-blue-500 text-white flex items-center justify-center">
           <i class="fa-solid fa-robot text-xs"></i>
         </div>
         <div>
@@ -49,7 +49,7 @@
       </div>
       {% else %}
       <div class="message max-w-prose ml-auto text-right">
-        <div class="chat-bubble user rounded-xl px-4 py-2 bg-blue-600 dark:bg-slate-600 whitespace-pre-wrap text-white">
+        <div class="chat-bubble user rounded-xl px-4 py-2 bg-blue-500 dark:bg-slate-600 whitespace-pre-wrap text-white">
           {{ msg.content | safe }}
         </div>
         {% if msg.time %}<div class="text-xs text-gray-500 mt-1">{{ msg.time }}</div>{% endif %}
@@ -93,7 +93,7 @@
       <textarea id="chat-input" rows="1" placeholder="Type a message…"
                 class="flex-1 border px-3 py-2 rounded resize-none"></textarea>
       <button id="send-btn"
-              class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">
+              class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">
         Send
       </button>
     </div>
@@ -118,12 +118,12 @@ function selected() {
 function addBubble(role, html, time) {
   const align = role === 'user' ? 'ml-auto text-right' : '';
   const bg    = role === 'user'
-               ? 'bg-blue-600 text-white dark:bg-slate-600'
+               ? 'bg-blue-500 text-white dark:bg-slate-600'
                : 'bg-gray-100 dark:bg-slate-700';
   let block;
   if (role === 'assist') {
     block = `<div class="message flex items-start gap-2 max-w-prose">
-                <div class="w-7 h-7 rounded-full bg-blue-600 text-white flex items-center justify-center">
+                <div class="w-7 h-7 rounded-full bg-blue-500 text-white flex items-center justify-center">
                   <i class="fa-solid fa-robot text-xs"></i>
                 </div>
                 <div>
@@ -194,8 +194,8 @@ qs('#filter').oninput = e => {
 document.querySelectorAll('.candidate-box').forEach(cb => {
   cb.addEventListener('change', e => {
     const lbl = e.target.closest('label');
-    if (e.target.checked) lbl.classList.add('ring', 'ring-indigo-400', 'bg-indigo-50', 'dark:bg-slate-700');
-    else lbl.classList.remove('ring', 'ring-indigo-400', 'bg-indigo-50', 'dark:bg-slate-700');
+    if (e.target.checked) lbl.classList.add('ring', 'ring-indigo-300', 'bg-indigo-100', 'dark:bg-slate-700');
+    else lbl.classList.remove('ring', 'ring-indigo-300', 'bg-indigo-100', 'dark:bg-slate-700');
   });
 });
 


### PR DESCRIPTION
## Summary
- lighten blue accents for chat bubbles and buttons
- lighten selected candidate highlight styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497e7375f48330a4595cf229f61896