### PR TITLE
Improve admin user page dark mode

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -44,9 +44,26 @@ input, textarea, select {
 body.dark input,
 body.dark textarea,
 body.dark select {
-  background-color: #1e293b;
-  color: #f1f5f9;
-  border-color: #475569;
+  background-color: #2d2d2d;
+  color: #eaeaea;
+  border-color: #444;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: #6b7280;
+}
+body.dark input::placeholder,
+body.dark textarea::placeholder {
+  color: #bbb;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: #4f46e5;
+  box-shadow: 0 0 5px rgba(99, 102, 241, 0.5);
 }
 #resume-form.drag-over {
   box-shadow: 0 0 0 4px rgba(59,130,246,0.4);
@@ -280,6 +297,13 @@ body.dark .chat-input-row {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  border-bottom: 1px solid #d1d5db;
+  padding-bottom: 0.5rem;
+}
+
+.dark .section-title {
+  color: #fff;
+  border-color: #374151;
 }
 
 .form-grid {
@@ -302,19 +326,26 @@ button:disabled {
 
 .role-badge {
   display: inline-block;
-  padding: 0.125rem 0.5rem;
+  padding: 2px 8px;
   border-radius: 9999px;
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: capitalize;
+  background: #6b7280;
+  color: #fff;
 }
 
 .role-badge.owner {
-  background: #c7d2fe;
-  color: #3730a3;
+  background: #6366f1;
+  color: #fff;
 }
 
 .role-badge.user {
-  background: #bbf7d0;
-  color: #065f46;
+  background: #22c55e;
+  color: #fff;
+}
+
+.role-badge.admin {
+  background: #ef4444;
+  color: #fff;
 }

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -3,13 +3,13 @@
 {% set active = "/admin/users" %}
 
 {% block body %}
-<div class="max-w-5xl mx-auto bg-white/70 backdrop-blur p-6 rounded-xl shadow space-y-8">
+<div class="max-w-5xl mx-auto card space-y-8">
   <div>
     <h2 class="section-title">👥 Existing Users</h2>
 
-    <table class="w-full text-sm border rounded-xl overflow-hidden shadow">
+    <table class="w-full text-sm border border-gray-200 dark:border-gray-600 rounded-xl overflow-hidden shadow">
       <thead>
-        <tr class="bg-gray-100 text-left">
+        <tr class="bg-gray-100 dark:bg-slate-700 text-left">
           <th class="px-4 py-2">Username</th>
           <th class="px-2 py-2">Role</th>
           <th class="px-2 py-2">Actions</th>
@@ -17,7 +17,7 @@
       </thead>
       <tbody>
         {% for u in users %}
-        <tr class="odd:bg-white even:bg-gray-50">
+        <tr class="odd:bg-white even:bg-gray-50 dark:odd:bg-slate-800/50 dark:even:bg-slate-700/50">
           <td class="px-4 py-2">{{ u.username }}</td>
           <td class="px-2 py-2"><span class="role-badge {{ u.role }}">{{ u.role }}</span></td>
           <td class="px-2 py-2 space-x-3 text-sm">
@@ -36,13 +36,22 @@
   <div>
     <h2 class="section-title">➕ Add New User</h2>
     <form id="create-user-form" action="/admin/users" method="post" class="form-grid">
-      <input name="username" placeholder="Username" class="border px-2 py-1 rounded" required>
-      <input name="password" type="password" placeholder="Password" class="border px-2 py-1 rounded" required>
-      <select name="role" class="border px-2 py-1 rounded">
+      <div class="relative">
+        <i class="fa-solid fa-user absolute left-2 top-1/2 -translate-y-1/2 text-gray-500"></i>
+        <input name="username" placeholder="Username" class="border pl-8 px-2 py-1 rounded w-full" required>
+      </div>
+      <div class="relative">
+        <i class="fa-solid fa-lock absolute left-2 top-1/2 -translate-y-1/2 text-gray-500"></i>
+        <input name="password" type="password" placeholder="Password" class="border pl-8 px-2 py-1 rounded w-full" required>
+      </div>
+      <div class="relative">
+        <i class="fa-solid fa-user-tie absolute left-2 top-1/2 -translate-y-1/2 text-gray-500"></i>
+        <select name="role" class="border pl-8 px-2 py-1 rounded w-full">
         <option value="user">user</option>
         <option value="owner">owner</option>
-      </select>
-      <button class="px-4 py-1 bg-blue-600 text-white rounded" disabled>Create</button>
+        </select>
+      </div>
+      <button class="px-4 py-1 bg-indigo-600 hover:bg-indigo-500 text-white rounded transition" disabled>Create</button>
       <p id="form-msg" class="text-sm"></p>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- update input styles for dark mode & focus
- refine section titles and role badges
- add icons and new colors on admin user form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498e14817483308c100a3dd9a67cec