### PR TITLE
Improve modal table styling

### DIFF
--- a/templates/projects.html
+++ b/templates/projects.html
@@ -22,7 +22,7 @@
       <button type="button" class="open-details text-blue-600 hover:underline flex items-center gap-1 mb-2"><i class="fa-solid fa-eye"></i>View details</button>
       <div class="hidden full-details">
         <div class="mt-2 whitespace-pre-wrap">{{ p.description }}</div>
-        <div class="overflow-auto">{{ p.table_html | safe }}</div>
+        <div>{{ p.table_html | safe }}</div>
       </div>
       <div class="actions mt-auto flex justify-end gap-3 text-sm">
         <a href="/edit_project?ts={{ p.ts.isoformat() }}" class="text-blue-600 hover:text-blue-800 flex items-center gap-1"><i class="fa-solid fa-pen"></i>Edit</a>

--- a/templates/resume_rank_table.html
+++ b/templates/resume_rank_table.html
@@ -1,27 +1,29 @@
-<table class="min-w-full border-collapse border border-gray-300 text-sm my-3">
-  <thead class="bg-gray-100">
+<div class="table-container bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-4 rounded-md shadow-md overflow-x-auto overflow-y-auto max-h-[400px] my-3">
+<table class="min-w-full border-collapse text-sm">
+  <thead class="bg-gray-100 dark:bg-gray-800">
     <tr>
-      <th class="border px-2 py-1 text-left">Candidate</th>
-      <th class="border px-2 py-1 text-center">Fit&nbsp;%</th>
+      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-left">Candidate</th>
+      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-center font-semibold text-indigo-600 dark:text-indigo-300">Fit&nbsp;%</th>
 
-      <th class="border px-2 py-1 text-center">
+      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-center">
         {% if expected_years %}Yrs/{{ expected_years }}{% else %}Yrs{% endif %}
       </th>
 
-      <th class="border px-2 py-1 text-left">Why Fit?</th>
-      <th class="border px-2 py-1 text-left">Improve</th>
+      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-left">Why Fit?</th>
+      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-left">Improve</th>
     </tr>
   </thead>
-  <tbody class="bg-white">
+  <tbody>
     {% for row in rows %}
-    <tr>
-      <td class="border px-2 py-1 font-medium">{{ row.name }}</td>
-      <td class="border px-2 py-1 text-center">{{ row.fit }}</td>
-      <td class="border px-2 py-1 text-center">{{ row.years }}</td>
+    <tr class="even:bg-gray-50 dark:even:bg-white/5 {{ 'bg-green-900/30' if row.fit|float >= 75 else 'bg-yellow-900/30' if row.fit|float >= 60 else 'bg-red-900/30' }}">
+      <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2 font-medium">{{ row.name }}</td>
+      <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2 text-center font-semibold text-indigo-600 dark:text-indigo-300">{{ row.fit }}</td>
+      <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2 text-center">{{ row.years }}</td>
 
-      <td class="border px-2 py-1">{{ row.why }}</td>
-      <td class="border px-2 py-1">{{ row.improve }}</td>
+      <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2">{{ row.why }}</td>
+      <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2">{{ row.improve }}</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
+</div>


### PR DESCRIPTION
## Summary
- style projects table in modal with dark mode in mind
- tweak row coloring for fit percentage
- remove redundant overflow wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684994db9b6883309f2b300b442414dc