### PR TITLE
Fix project match years test

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -177,7 +177,7 @@ async def chat(request: Request, chat_data: ChatRequest = Body(...), user=Depend
         {"role": "assistant", "content": assistant_reply, "time": ts},
     ])
     await main.chat_upsert(user_id, {"messages": history})
-    return {"reply": safe_reply, "time": ts}
+    return JSONResponse({"reply": safe_reply, "time": ts})
 
 @router.post("/chat_action", response_class=HTMLResponse)
 async def chat_action(


### PR DESCRIPTION
## Summary
- handle numpy stubs and fallback maths when matching projects
- render a minimal HTML table if templates return empty
- await `add_project_history` only when needed
- ensure chat endpoint returns a JSONResponse

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afa85482c8330b8d1ae12aa32938f