### PR TITLE
Fix chat control readability in light mode

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -59,7 +59,7 @@
     </div>
 
       {# quick prompts row #}
-      <div id="quick-prompts" class="border-t bg-white shadow-sm dark:bg-gray-800 p-4 space-y-2 text-sm">
+      <div id="quick-prompts" class="border-t bg-gray-100 shadow-sm dark:bg-gray-800 p-4 space-y-2 text-sm">
         {% for grp, items in quick_prompts|groupby('group') %}
         <div class="flex items-center flex-wrap gap-2">
           <span class="font-medium mr-1">{{ grp }}</span>
@@ -73,7 +73,7 @@
       </div>
 
       {# chat mode toggle #}
-      <div class="border-t bg-white shadow-sm dark:bg-gray-800 p-4 flex items-center gap-2 text-sm">
+      <div class="border-t bg-gray-100 shadow-sm dark:bg-gray-800 p-4 flex items-center gap-2 text-sm">
         <span class="font-medium">Chat mode:</span>
         <input type="hidden" id="chat-mode" value="general">
         <div id="chat-mode-group" class="flex gap-2">

--- a/templates_en/chat.html
+++ b/templates_en/chat.html
@@ -59,7 +59,7 @@
     </div>
 
       {# quick prompts row #}
-      <div id="quick-prompts" class="border-t bg-white shadow-sm dark:bg-gray-800 p-4 space-y-2 text-sm">
+      <div id="quick-prompts" class="border-t bg-gray-100 shadow-sm dark:bg-gray-800 p-4 space-y-2 text-sm">
         {% for grp, items in quick_prompts|groupby('group') %}
         <div class="flex items-center flex-wrap gap-2">
           <span class="font-medium mr-1">{{ grp }}</span>
@@ -73,7 +73,7 @@
       </div>
 
       {# chat mode toggle #}
-      <div class="border-t bg-white shadow-sm dark:bg-gray-800 p-4 flex items-center gap-2 text-sm">
+      <div class="border-t bg-gray-100 shadow-sm dark:bg-gray-800 p-4 flex items-center gap-2 text-sm">
         <span class="font-medium">Chat mode:</span>
         <input type="hidden" id="chat-mode" value="general">
         <div id="chat-mode-group" class="flex gap-2">


### PR DESCRIPTION
## Summary
- darken the quick prompts and chat mode boxes in light theme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b5620532083308037f2c3490ab5eb