### PR TITLE
Fix header parsing for multilingual candidate tables

### DIFF
--- a/main.py
+++ b/main.py
@@ -685,7 +685,10 @@ async def match_project(
         if not ln.startswith("|"):
             continue
         # skip header and alignment
-        if ln.lower().startswith("| candidate") or alignment_re.match(ln):
+        ln_l = ln.lower()
+        if (ln_l.startswith("| candidate") or
+                ln_l.startswith("| kandidaat") or
+                alignment_re.match(ln)):
             continue
 
         cells = [c.strip() for c in ln.split("|")[1:-1]]


### PR DESCRIPTION
## Summary
- allow parsing of markdown tables that use `| kandidaat` header
- skip rows starting with `| kandidaat` when building the table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd732fe9083309fa9e43e9e090aa1