### PR TITLE
Improve project uploads

### DIFF
--- a/main.py
+++ b/main.py
@@ -529,6 +529,7 @@ async def match_project(
     description: str = Form(""),
     file: UploadFile = File(None),
     candidate_ids: Optional[List[str]] = Form(None),
+    priority_skills: str = Form(""),
 ):
     session_user = await get_current_user(request.cookies.get(COOKIE_NAME))
     user_id = session_user["username"] if session_user else "anon"
@@ -653,6 +654,13 @@ async def match_project(
     )
     if expected_years:
         rubric += f"\n\nDoelervaring: circa {expected_years} jaar"
+    rubric += (
+        "\n\nGebruik concrete voorbeelden uit het cv; "
+        "vervang vage zinnen als 'ervaring met digitalisering en informatiebeveiliging' "
+        "door specifieke prestaties (bv. 'heeft ISO 27001 geïmplementeerd bij X')."
+    )
+    if priority_skills.strip():
+        rubric += f"\n\nLeg extra nadruk op: {priority_skills.strip()}"
 
     prompt = (
         f"Projectbeschrijving (focus op rol / domein / ervaring):\n"

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -90,6 +90,7 @@
         <i class="fa-solid fa-paperclip"></i>
       </button>
       <input id="project-file" type="file" accept=".pdf,.docx" class="hidden">
+      <input id="priority-skills" type="text" placeholder="Prioritaire skills" class="border px-2 py-1 rounded w-40">
       <textarea id="chat-input" rows="1" placeholder="Type a message…"
                 class="flex-1 border px-3 py-2 rounded resize-none"></textarea>
       <button id="send-btn"
@@ -262,6 +263,8 @@ qs('#project-file').onchange = async e => {
   const fd = new FormData();
   fd.append('file', f);
   selected().forEach(id => fd.append('candidate_ids', id));
+  const skills = qs('#priority-skills').value.trim();
+  if (skills) fd.append('priority_skills', skills);
   addBubble('user', '[uploaded project]', timeStr(Date.now()));
   showTyping();
   const html = await (await fetch('/match_project', {method: 'POST', body: fd})).text();

--- a/templates/resume_rank_table.html
+++ b/templates/resume_rank_table.html
@@ -3,7 +3,9 @@
   <thead class="bg-gray-100 dark:bg-gray-800">
     <tr>
       <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-left">Kandidaat</th>
-      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-center font-semibold text-indigo-600 dark:text-indigo-300">Fit&nbsp;%</th>
+      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-center font-semibold text-indigo-600 dark:text-indigo-300">
+        <span title="Cosine-gemeten matchscore, handmatig ±15 punten bijgesteld">Fit&nbsp;%</span>
+      </th>
 
       <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-center">
         {% if expected_years %}Jaren/{{ expected_years }}{% else %}Jaren{% endif %}

--- a/templates_en/chat.html
+++ b/templates_en/chat.html
@@ -90,6 +90,7 @@
         <i class="fa-solid fa-paperclip"></i>
       </button>
       <input id="project-file" type="file" accept=".pdf,.docx" class="hidden">
+      <input id="priority-skills" type="text" placeholder="Priority skills" class="border px-2 py-1 rounded w-40">
       <textarea id="chat-input" rows="1" placeholder="Type a message…"
                 class="flex-1 border px-3 py-2 rounded resize-none"></textarea>
       <button id="send-btn"
@@ -262,6 +263,8 @@ qs('#project-file').onchange = async e => {
   const fd = new FormData();
   fd.append('file', f);
   selected().forEach(id => fd.append('candidate_ids', id));
+  const skills = qs('#priority-skills').value.trim();
+  if (skills) fd.append('priority_skills', skills);
   addBubble('user', '[uploaded project]', timeStr(Date.now()));
   showTyping();
   const html = await (await fetch('/match_project', {method: 'POST', body: fd})).text();

--- a/templates_en/resume_rank_table.html
+++ b/templates_en/resume_rank_table.html
@@ -3,7 +3,9 @@
   <thead class="bg-gray-100 dark:bg-gray-800">
     <tr>
       <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-left">Candidate</th>
-      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-center font-semibold text-indigo-600 dark:text-indigo-300">Fit&nbsp;%</th>
+      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-center font-semibold text-indigo-600 dark:text-indigo-300">
+        <span title="Cosine-based match score adjusted by ±15 pts">Fit&nbsp;%</span>
+      </th>
 
       <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-center">
         {% if expected_years %}Years/{{ expected_years }}{% else %}Years{% endif %}


### PR DESCRIPTION
## Summary
- add an input for priority skills on the chat page
- send the extra field when uploading a project
- accept `priority_skills` in `/match_project`
- steer GPT to use concrete examples and mention priority skills
- explain Fit score via tooltip in ranking tables

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bd8a5db408330ab15cb6ef0908cc4