### PR TITLE
Replace years column with score explanation

### DIFF
--- a/main.py
+++ b/main.py
@@ -609,7 +609,6 @@ async def match_project(
     # 4️⃣ build GPT prompt ----------------------------------------------------
     expected_years = extract_years_requirement(description)
     snippets = []
-    years_info = []
     for m in matches:
         tags_str = ", ".join(m.metadata.get('tags', []))
         tag_part = f" [tags: {tags_str}]" if tags_str else ""
@@ -617,13 +616,10 @@ async def match_project(
 
         if expected_years and years is not None:
             years_part = f" ({years}/{expected_years} yrs)"
-            years_info.append(f"{years}/{expected_years}")
         elif years is not None:
             years_part = f" ({years} yrs)"
-            years_info.append(str(years))
         else:
             years_part = ""
-            years_info.append("—" if expected_years else "—")
 
         snippet = (
             f"- **{m.metadata['name']}**{years_part}{tag_part}: "
@@ -712,11 +708,6 @@ async def match_project(
                 }
             )
 
-    # add experience column if lengths match
-    if rows and len(rows) == len(years_info):
-        for r, y in zip(rows, years_info):
-            r["years"] = y
-
     # fallback – if parsing still fails just show raw markdown
     if not rows:
         table_html = "<pre style='white-space:pre-wrap'>" + table_md + "</pre>"
@@ -725,15 +716,14 @@ async def match_project(
         tpl = templates_nl if lang == "nl" else templates_en
         table_html = tpl.get_template("resume_rank_table.html").render(
             rows=rows,
-            expected_years=expected_years,
         )
         if not table_html.strip():
             # simple fallback when Jinja templates are stubbed during tests
-            header_cells = ["Candidate", "Fit %", "Yrs" + (f"/{expected_years}" if expected_years else ""), "Why Fit?", "Improve"]
+            header_cells = ["Candidate", "Fit %", "Why Fit?", "Improve"]
             header = "<tr>" + "".join(f"<th>{c}</th>" for c in header_cells) + "</tr>"
             rows_html = "".join(
                 "<tr>" + "".join(
-                    f"<td>{r.get(k, '')}</td>" for k in ["name", "fit", "years", "why", "improve"]
+                    f"<td>{r.get(k, '')}</td>" for k in ["name", "fit", "why", "improve"]
                 ) + "</tr>" for r in rows
             )
             table_html = f"<table>{header}{rows_html}</table>"

--- a/templates/resume_rank_table.html
+++ b/templates/resume_rank_table.html
@@ -7,10 +7,6 @@
         <span title="Cosine-gemeten matchscore, handmatig ±15 punten bijgesteld">Fit&nbsp;%</span>
       </th>
 
-      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-center">
-        {% if expected_years %}Jaren/{{ expected_years }}{% else %}Jaren{% endif %}
-      </th>
-
       <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-left">Waarom geschikt?</th>
       <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-left">Verbeter</th>
     </tr>
@@ -20,12 +16,14 @@
     <tr class="even:bg-gray-50 dark:even:bg-white/5 {{ 'bg-green-900/30' if row.fit|float >= 75 else 'bg-yellow-900/30' if row.fit|float >= 60 else 'bg-red-900/30' }}">
       <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2 font-medium">{{ row.name }}</td>
       <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2 text-center font-semibold text-indigo-600 dark:text-indigo-300">{{ row.fit }}</td>
-      <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2 text-center">{{ row.years }}</td>
-
       <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2">{{ row.why }}</td>
       <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2">{{ row.improve }}</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
+<p class="text-xs text-gray-600 dark:text-gray-300 mt-2">
+  Fit % geeft aan hoe goed het cv bij het project past. De score is gebaseerd
+  op cosine-similariteit en kan ±15 punten worden bijgesteld.
+</p>
 </div>

--- a/templates_en/resume_rank_table.html
+++ b/templates_en/resume_rank_table.html
@@ -7,10 +7,6 @@
         <span title="Cosine-based match score adjusted by ±15 pts">Fit&nbsp;%</span>
       </th>
 
-      <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-center">
-        {% if expected_years %}Years/{{ expected_years }}{% else %}Years{% endif %}
-      </th>
-
       <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-left">Why Fit?</th>
       <th class="border-b border-gray-300 dark:border-gray-700 px-4 py-2 text-left">Improve</th>
     </tr>
@@ -20,12 +16,14 @@
     <tr class="even:bg-gray-50 dark:even:bg-white/5 {{ 'bg-green-900/30' if row.fit|float >= 75 else 'bg-yellow-900/30' if row.fit|float >= 60 else 'bg-red-900/30' }}">
       <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2 font-medium">{{ row.name }}</td>
       <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2 text-center font-semibold text-indigo-600 dark:text-indigo-300">{{ row.fit }}</td>
-      <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2 text-center">{{ row.years }}</td>
-
       <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2">{{ row.why }}</td>
       <td class="border-b border-gray-200 dark:border-gray-700 px-4 py-2">{{ row.improve }}</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
+<p class="text-xs text-gray-600 dark:text-gray-300 mt-2">
+  Fit % shows how well the résumé matches the project. The score is based on
+  cosine similarity and can be adjusted by ±15 points.
+</p>
 </div>

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -66,7 +66,7 @@ def test_extract_years_requirement():
 
 
 @pytest.mark.asyncio
-async def test_match_project_years_column(monkeypatch):
+async def test_match_project_score_explanation(monkeypatch):
     table = (
         "| Candidate | Fit % | Why Fit? | Improve |\n"
         "|:--|:--:|:--|:--|\n"
@@ -111,7 +111,8 @@ async def test_match_project_years_column(monkeypatch):
         DummyRequest("/match"),
         description="need 3 years", file=None, candidate_ids=None
     )
-    assert "2/3" in resp.body.decode()
+    html = resp.body.decode()
+    assert "Fit % geeft aan" in html
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- simplify match results table by removing the Years column
- explain the Fit % scoring under the table
- adjust project matching logic for new layout
- update test accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdb26e0d88330ae9e0ac6ba8fa984