### PR TITLE
Remove fit explanation and priority skills field

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -58,6 +58,13 @@ body.dark textarea::placeholder {
   color: #bbb;
 }
 
+# ensure chat input text is dark in light mode
+# dark mode already handled above
+# -------------------------------------
+#chat-input {
+  color: #000;
+}
+
 input:focus,
 textarea:focus,
 select:focus {

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -90,7 +90,6 @@
         <i class="fa-solid fa-paperclip"></i>
       </button>
       <input id="project-file" type="file" accept=".pdf,.docx" class="hidden">
-      <input id="priority-skills" type="text" placeholder="Prioritaire skills" class="border px-2 py-1 rounded w-40">
       <textarea id="chat-input" rows="1" placeholder="Type a message…"
                 class="flex-1 border px-3 py-2 rounded resize-none"></textarea>
       <button id="send-btn"
@@ -263,8 +262,6 @@ qs('#project-file').onchange = async e => {
   const fd = new FormData();
   fd.append('file', f);
   selected().forEach(id => fd.append('candidate_ids', id));
-  const skills = qs('#priority-skills').value.trim();
-  if (skills) fd.append('priority_skills', skills);
   addBubble('user', '[uploaded project]', timeStr(Date.now()));
   showTyping();
   const html = await (await fetch('/match_project', {method: 'POST', body: fd})).text();

--- a/templates/resume_rank_table.html
+++ b/templates/resume_rank_table.html
@@ -22,8 +22,4 @@
     {% endfor %}
   </tbody>
 </table>
-<p class="text-xs text-gray-600 dark:text-gray-300 mt-2">
-  Fit % geeft aan hoe goed het cv bij het project past. De score is gebaseerd
-  op cosine-similariteit en kan ±15 punten worden bijgesteld.
-</p>
 </div>

--- a/templates_en/chat.html
+++ b/templates_en/chat.html
@@ -90,7 +90,6 @@
         <i class="fa-solid fa-paperclip"></i>
       </button>
       <input id="project-file" type="file" accept=".pdf,.docx" class="hidden">
-      <input id="priority-skills" type="text" placeholder="Priority skills" class="border px-2 py-1 rounded w-40">
       <textarea id="chat-input" rows="1" placeholder="Type a message…"
                 class="flex-1 border px-3 py-2 rounded resize-none"></textarea>
       <button id="send-btn"
@@ -263,8 +262,6 @@ qs('#project-file').onchange = async e => {
   const fd = new FormData();
   fd.append('file', f);
   selected().forEach(id => fd.append('candidate_ids', id));
-  const skills = qs('#priority-skills').value.trim();
-  if (skills) fd.append('priority_skills', skills);
   addBubble('user', '[uploaded project]', timeStr(Date.now()));
   showTyping();
   const html = await (await fetch('/match_project', {method: 'POST', body: fd})).text();

--- a/templates_en/resume_rank_table.html
+++ b/templates_en/resume_rank_table.html
@@ -22,8 +22,4 @@
     {% endfor %}
   </tbody>
 </table>
-<p class="text-xs text-gray-600 dark:text-gray-300 mt-2">
-  Fit % shows how well the résumé matches the project. The score is based on
-  cosine similarity and can be adjusted by ±15 points.
-</p>
 </div>

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -112,7 +112,7 @@ async def test_match_project_score_explanation(monkeypatch):
         description="need 3 years", file=None, candidate_ids=None
     )
     html = resp.body.decode()
-    assert "Fit % geeft aan" in html
+    assert "<table" in html
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- drop explanatory text from resume rank table
- remove 'priority skills' field in chat
- enforce darker input text for chat message box
- update test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdcfa90f4833095fe2bf991e8043c