### PR TITLE
Add candidate-project cross links

### DIFF
--- a/main.py
+++ b/main.py
@@ -745,12 +745,15 @@ async def match_project(
         "table_md": table_md,
         "table_html": table_html,
         "candidates": [
-            {"name": m.metadata["name"],
-             "fit": m.sim_pct,
-             "text": m.metadata["text"]}
+            {
+                "id": m.id,
+                "name": m.metadata["name"],
+                "fit": m.sim_pct,
+                "text": m.metadata["text"],
+            }
             for m in matches
         ],
-    }
+   }
 
     res = add_project_history(user_id, project)
     if inspect.isawaitable(res):
@@ -814,6 +817,7 @@ async def list_resumes(
                 "years": d.get("years"),
                 "file_type": d.get("file_type", ""),
                 "added": added,
+                "projects": [p.isoformat() if hasattr(p, "isoformat") else p for p in d.get("projects", [])],
             }
         )
 

--- a/mongo_utils.py
+++ b/mongo_utils.py
@@ -301,6 +301,14 @@ async def add_project_history(user_id: str, project: dict):
         upsert=True,
     )
 
+    # also store a back-reference on each candidate
+    candidate_ids = [c.get("id") for c in project.get("candidates", []) if c.get("id")]
+    if candidate_ids:
+        await _resumes.update_many(
+            {"resume_id": {"$in": candidate_ids}},
+            {"$addToSet": {"projects": project["ts"]}},
+        )
+
 
 async def delete_project(user_id: str, ts_iso: str) -> int:
     """Delete a project by timestamp for the given user."""

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -17,7 +17,9 @@
         <span class="text-xs date-label">{{ p.ts.strftime('%Y-%m-%d') }}</span>
       </div>
       <div class="text-xs flex flex-wrap gap-1 mb-2">
-        {% for c in p.candidates %}<span class="chip">{{ c.name }} {{ c.fit }}%</span>{% endfor %}
+        {% for c in p.candidates %}
+          <a href="/edit_resume?id={{ c.id }}" class="chip">{{ c.name }} {{ c.fit }}%</a>
+        {% endfor %}
       </div>
       <button type="button" class="open-details text-blue-600 hover:underline flex items-center gap-1 mb-2"><i class="fa-solid fa-eye"></i>Details bekijken</button>
       <div class="hidden full-details">

--- a/templates/resumes.html
+++ b/templates/resumes.html
@@ -38,6 +38,9 @@
       <div class="text-xs text-gray-600 dark:text-gray-400 mb-2">
         {{ r.file_type|upper }}{% if r.years is not none %} · {{ r.years }} jr{% endif %}
       </div>
+      <div class="text-xs mb-2">
+        {{ r.projects|length }} project{{ '' if r.projects|length == 1 else 's' }}
+      </div>
       <div class="actions mt-auto flex justify-end gap-3 text-sm">
         <a href="/edit_resume?id={{ r.id }}" class="text-blue-600 hover:text-blue-800 flex items-center gap-1"><i class="fa-solid fa-pen"></i>Bewerken</a>
         <form action="/delete_resume" method="post" class="delete-form inline">


### PR DESCRIPTION
## Summary
- include resume IDs in saved project data
- update add_project_history to store back-references on resumes
- display number of linked projects on each resume
- link candidate chips on project history page to the resume editor

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685271e0205483308d6ee70248e9667a