### PR TITLE
Add project status and filtering

### DIFF
--- a/mongo_utils.py
+++ b/mongo_utils.py
@@ -340,3 +340,18 @@ async def update_project_description(
         {"$set": {"projects.$.description": description}},
     )
     return res.modified_count
+
+
+async def update_project_status(user_id: str, ts_iso: str, status: str) -> int:
+    """Update status for a stored project."""
+    if await _guard("update_project_status"):
+        return 0
+    try:
+        ts = datetime.fromisoformat(ts_iso)
+    except ValueError:
+        return 0
+    res = await chats.update_one(
+        {"user_id": user_id, "projects.ts": ts},
+        {"$set": {"projects.$.status": status}},
+    )
+    return res.modified_count

--- a/static/styles.css
+++ b/static/styles.css
@@ -452,3 +452,22 @@ button:disabled {
   background: #ef4444;
   color: #fff;
 }
+
+.status-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  background: #6b7280;
+  color: #fff;
+}
+
+.status-badge.active {
+  background: #22c55e;
+}
+
+.status-badge.archived {
+  background: #9ca3af;
+}

--- a/templates/edit_project.html
+++ b/templates/edit_project.html
@@ -14,6 +14,13 @@
       <label class="block font-medium mb-1">Beschrijving</label>
       <textarea name="description" rows="10" class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">{{ project.description }}</textarea>
     </div>
+    <div>
+      <label class="block font-medium mb-1">Status</label>
+      <select name="status" class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+        <option value="active" {% if project.status == 'active' or not project.status %}selected{% endif %}>Actief</option>
+        <option value="archived" {% if project.status == 'archived' %}selected{% endif %}>Gearchiveerd</option>
+      </select>
+    </div>
     <button class="px-6 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700">Opslaan</button>
   </form>
 </div>

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -5,6 +5,13 @@
 {% block body %}
 <div class="max-w-6xl mx-auto space-y-6">
   <input id="search" type="text" placeholder="Zoeken…" class="w-full sm:w-80 px-3 py-2 border rounded shadow-sm">
+  <div>
+    {% if active_only %}
+      <a href="/projects" class="chip">Alle projecten <i class="fa-solid fa-xmark"></i></a>
+    {% else %}
+      <a href="/projects?active=1" class="chip">Alleen actieve</a>
+    {% endif %}
+  </div>
 
   {% if projects %}
   <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" id="project-grid">
@@ -14,7 +21,12 @@
         <h2 class="font-semibold break-words mr-2 project-snippet">
           {{ p.description[:200] }}{% if p.description|length > 200 %}&hellip;{% endif %}
         </h2>
-        <span class="text-xs date-label">{{ p.ts.strftime('%Y-%m-%d') }}</span>
+        <div class="flex flex-col items-end gap-1">
+          <span class="text-xs date-label">{{ p.ts.strftime('%Y-%m-%d') }}</span>
+          <span class="status-badge {{ p.status or 'active' }}">
+            {{ 'Actief' if p.status != 'archived' else 'Gearchiveerd' }}
+          </span>
+        </div>
       </div>
       <div class="text-xs flex flex-wrap gap-1 mb-2">
         {% for c in p.candidates %}

--- a/templates_en/edit_project.html
+++ b/templates_en/edit_project.html
@@ -14,6 +14,13 @@
       <label class="block font-medium mb-1">Description</label>
       <textarea name="description" rows="10" class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">{{ project.description }}</textarea>
     </div>
+    <div>
+      <label class="block font-medium mb-1">Status</label>
+      <select name="status" class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+        <option value="active" {% if project.status == 'active' or not project.status %}selected{% endif %}>Active</option>
+        <option value="archived" {% if project.status == 'archived' %}selected{% endif %}>Archived</option>
+      </select>
+    </div>
     <button class="px-6 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700">Save</button>
   </form>
 </div>

--- a/templates_en/projects.html
+++ b/templates_en/projects.html
@@ -5,6 +5,13 @@
 {% block body %}
 <div class="max-w-6xl mx-auto space-y-6">
   <input id="search" type="text" placeholder="Search…" class="w-full sm:w-80 px-3 py-2 border rounded shadow-sm">
+  <div>
+    {% if active_only %}
+      <a href="/projects" class="chip">All projects <i class="fa-solid fa-xmark"></i></a>
+    {% else %}
+      <a href="/projects?active=1" class="chip">Active only</a>
+    {% endif %}
+  </div>
 
   {% if projects %}
   <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" id="project-grid">
@@ -14,7 +21,12 @@
         <h2 class="font-semibold break-words mr-2 project-snippet">
           {{ p.description[:200] }}{% if p.description|length > 200 %}&hellip;{% endif %}
         </h2>
-        <span class="text-xs date-label">{{ p.ts.strftime('%Y-%m-%d') }}</span>
+        <div class="flex flex-col items-end gap-1">
+          <span class="text-xs date-label">{{ p.ts.strftime('%Y-%m-%d') }}</span>
+          <span class="status-badge {{ p.status or 'active' }}">
+            {{ 'Active' if p.status != 'archived' else 'Archived' }}
+          </span>
+        </div>
       </div>
       <div class="text-xs flex flex-wrap gap-1 mb-2">
         {% for c in p.candidates %}<span class="chip">{{ c.name }} {{ c.fit }}%</span>{% endfor %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -376,6 +376,7 @@ stub_mongo_utils.resumes_collection = None
 stub_mongo_utils.add_project_history = _async_none
 stub_mongo_utils.delete_project = _async_one
 stub_mongo_utils.update_project_description = _async_one
+stub_mongo_utils.update_project_status = _async_one
 stub_mongo_utils.ensure_indexes = _async_none
 
 class DummyColl:


### PR DESCRIPTION
## Summary
- save new projects with `status: active`
- allow editing project status
- show status badges on project overview and filter active projects
- add CSS for project status
- stub `update_project_status` in tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685275a9986c8330968c057b0e9dd321