### PR TITLE
Add Pinecone project management utilities

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ from mongo_utils import (
 from pymongo import errors
 from pinecone_utils import (
     add_resume_to_pinecone,
+    add_project_to_pinecone,
     embed_text,
     index,
     search_best_resumes,
@@ -756,6 +757,10 @@ async def match_project(
         ],
         "status": "active",
     }
+    ts = datetime.utcnow()
+    project["ts"] = ts
+    project_id = f"{user_id}:{ts.isoformat()}"
+    add_project_to_pinecone(description, project_id, {"user_id": user_id})
 
     res = add_project_history(user_id, project)
     if inspect.isawaitable(res):

--- a/mongo_utils.py
+++ b/mongo_utils.py
@@ -11,7 +11,7 @@ from bson import ObjectId
 from passlib.hash import bcrypt
 
 from settings import settings
-from pinecone_utils import add_resume_to_pinecone
+from pinecone_utils import add_resume_to_pinecone, delete_project_from_pinecone
 
 # ------------------------------------------------------------------ #
 # 0) environment & configuration                                     #
@@ -322,6 +322,9 @@ async def delete_project(user_id: str, ts_iso: str) -> int:
         {"user_id": user_id},
         {"$pull": {"projects": {"ts": ts}}},
     )
+    if res.modified_count:
+        project_id = f"{user_id}:{ts_iso}"
+        delete_project_from_pinecone(project_id)
     return res.modified_count
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -476,6 +476,9 @@ stub_pinecone_utils.add_resume_to_pinecone = lambda *a, **kw: None
 stub_pinecone_utils.embed_text = lambda *a, **kw: []
 stub_pinecone_utils.index = None
 stub_pinecone_utils.search_best_resumes = lambda *a, **kw: []
+stub_pinecone_utils.add_project_to_pinecone = lambda *a, **kw: None
+stub_pinecone_utils.search_best_projects = lambda *a, **kw: []
+stub_pinecone_utils.delete_project_from_pinecone = lambda *a, **kw: None
 sys.modules['pinecone_utils'] = stub_pinecone_utils
 
 # ── finally load main.py so tests can import it ───────────────────────────────

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,7 @@ def authed(monkeypatch):
     )
     monkeypatch.setattr(main, "openai", fake_openai)
     monkeypatch.setattr(main, "add_resume_to_pinecone", lambda *a, **k: None)
+    monkeypatch.setattr(main, "add_project_to_pinecone", lambda *a, **k: None)
     async def _insert(doc):
         return None
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -100,6 +100,7 @@ async def test_match_project_score_explanation(monkeypatch):
 
     monkeypatch.setattr(main, "index", DummyIndex())
     monkeypatch.setattr(main, "add_project_history", lambda *a, **k: None)
+    monkeypatch.setattr(main, "add_project_to_pinecone", lambda *a, **k: None)
     async def _req_login():
         return {"username": "u"}
     async def _cur_user(*a, **k):
@@ -150,6 +151,7 @@ async def test_match_project_dutch_header(monkeypatch):
 
     monkeypatch.setattr(main, "index", DummyIndex())
     monkeypatch.setattr(main, "add_project_history", lambda *a, **k: None)
+    monkeypatch.setattr(main, "add_project_to_pinecone", lambda *a, **k: None)
     async def _req_login():
         return {"username": "u"}
     async def _cur_user(*a, **k):


### PR DESCRIPTION
## Summary
- allow storing, searching, and deleting project embeddings in Pinecone
- push project embeddings from `match_project`
- remove project embeddings via Mongo deletion
- update tests with new pinecone stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852799e8724833085d449b580bbac6b