### PR TITLE
Link uploaded resumes to existing projects

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -378,6 +378,11 @@ stub_mongo_utils.delete_project = _async_one
 stub_mongo_utils.update_project_description = _async_one
 stub_mongo_utils.update_project_status = _async_one
 stub_mongo_utils.ensure_indexes = _async_none
+class _Chats:
+    async def update_one(self, *a, **kw):
+        return None
+
+stub_mongo_utils.chats = _Chats()
 
 class DummyColl:
     def __getattr__(self, name):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,10 +30,13 @@ def authed(monkeypatch):
     monkeypatch.setattr(main, "openai", fake_openai)
     monkeypatch.setattr(main, "add_resume_to_pinecone", lambda *a, **k: None)
     monkeypatch.setattr(main, "add_project_to_pinecone", lambda *a, **k: None)
+    async def _link(*a, **k):
+        pass
+    monkeypatch.setattr(main, "link_resume_to_projects", _link)
     async def _insert(doc):
         return None
 
-    monkeypatch.setattr(main, "resumes_collection", types.SimpleNamespace(insert_one=_insert))
+    monkeypatch.setattr(main, "resumes_collection", types.SimpleNamespace(insert_one=_insert, update_one=lambda *a, **k: None))
     async def _render(*a, **kw):
         return HTMLResponse("OK")
 

--- a/tests/test_upload_resume.py
+++ b/tests/test_upload_resume.py
@@ -13,8 +13,13 @@ def client(monkeypatch):
     class FakeColl:
         async def insert_one(self, doc):
             stored.append(doc)
+        async def update_one(self, *a, **k):
+            pass
 
     monkeypatch.setattr(main, "add_resume_to_pinecone", lambda *a, **k: None)
+    async def _link(*a, **k):
+        pass
+    monkeypatch.setattr(main, "link_resume_to_projects", _link)
     monkeypatch.setattr(main, "resumes_collection", FakeColl())
     async def _login():
         return {"username": "user"}


### PR DESCRIPTION
## Summary
- connect Mongo stub `chats` collection for tests
- handle linking resumes to related projects on upload
- stub new helper in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527ac3cdf88330b5a81da8fd87f664