### PR TITLE
Add match page and route

### DIFF
--- a/main.py
+++ b/main.py
@@ -568,6 +568,26 @@ async def match_project_logic(description: str,
     return "\n".join(f"* **{m.name}** – {m.score}%" for m in matches[:5])
 
 # ---------------------------------------------------------------------------
+# /match – simple form to rank candidates
+# ---------------------------------------------------------------------------
+@app.get("/match", response_class=HTMLResponse)
+async def match_form(request: Request, user=Depends(require_login)):
+    candidates = [
+        {
+            "id": r.get("resume_id"),
+            "name": r.get("name"),
+        }
+        for r in await resumes_all()
+    ]
+    return await render(
+        request,
+        "match_form.html",
+        {"candidates": candidates},
+        page_title="Match",
+        active="/match",
+    )
+
+# ---------------------------------------------------------------------------
 # /match_project – returns the full HTML table fragment
 # ---------------------------------------------------------------------------
 @app.post("/match_project", response_class=HTMLResponse)

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -27,6 +27,7 @@
         <a href="/" class="flex items-center gap-2 px-3 py-1 rounded-full transition-colors {{ 'bg-indigo-100 text-indigo-700 dark:bg-slate-700 dark:text-indigo-300' if active=='/' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-house"></i>Start</a>
         <a href="/resumes" class="flex items-center gap-2 px-3 py-1 rounded-full transition-colors {{ 'bg-indigo-100 text-indigo-700 dark:bg-slate-700 dark:text-indigo-300' if active=='/resumes' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-file-lines"></i>CV's</a>
         <a href="/chat" class="flex items-center gap-2 px-3 py-1 rounded-full transition-colors {{ 'bg-indigo-100 text-indigo-700 dark:bg-slate-700 dark:text-indigo-300' if active=='/chat' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-comments"></i>Chat</a>
+        <a href="/match" class="flex items-center gap-2 px-3 py-1 rounded-full transition-colors {{ 'bg-indigo-100 text-indigo-700 dark:bg-slate-700 dark:text-indigo-300' if active=='/match' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-star"></i>Match</a>
         <a href="/projects" class="flex items-center gap-2 px-3 py-1 rounded-full transition-colors {{ 'bg-indigo-100 text-indigo-700 dark:bg-slate-700 dark:text-indigo-300' if active=='/projects' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-table-list"></i>Projecten</a>
       </div>
       <div class="mt-4 pt-4 border-t space-y-2">

--- a/templates/match_form.html
+++ b/templates/match_form.html
@@ -1,0 +1,49 @@
+{% extends "_base.html" %}
+{% set active = "/match" %}
+{% set page_title = "Match" %}
+
+{% block body %}
+<div class="max-w-4xl mx-auto space-y-6">
+  <form id="match-form" class="card space-y-4">
+    <div>
+      <label class="block font-medium mb-1">Beschrijving</label>
+      <textarea name="description" rows="6" class="w-full border rounded px-3 py-2"></textarea>
+    </div>
+    <div>
+      <label class="block font-medium mb-1">Bestand (optioneel)</label>
+      <input type="file" name="file" accept=".pdf,.docx" class="w-full">
+    </div>
+    <div>
+      <label class="block font-medium mb-1">Prioriteitsvaardigheden</label>
+      <input type="text" name="priority_skills" class="w-full border rounded px-3 py-2">
+    </div>
+    <div>
+      <span class="block font-medium mb-1">Kandidaten</span>
+      <div class="space-y-1">
+        {% for c in candidates %}
+        <label class="flex items-center gap-2">
+          <input type="checkbox" name="candidate_ids" value="{{ c.id }}" class="candidate-box">
+          <span>{{ c.name }}</span>
+        </label>
+        {% endfor %}
+      </div>
+    </div>
+    <button type="submit" class="px-4 py-2 rounded bg-indigo-600 text-white">Match</button>
+  </form>
+  <div id="results"></div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.getElementById('match-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const form = e.target;
+  const fd = new FormData(form);
+  const results = document.getElementById('results');
+  results.innerHTML = '...';
+  const resp = await fetch('/match_project', {method: 'POST', body: fd});
+  results.innerHTML = await resp.text();
+});
+</script>
+{% endblock %}

--- a/templates_en/_base.html
+++ b/templates_en/_base.html
@@ -27,6 +27,7 @@
         <a href="/" class="flex items-center gap-2 px-3 py-1 rounded-full transition-colors {{ 'bg-indigo-100 text-indigo-700 dark:bg-slate-700 dark:text-indigo-300' if active=='/' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-house"></i>Home</a>
         <a href="/resumes" class="flex items-center gap-2 px-3 py-1 rounded-full transition-colors {{ 'bg-indigo-100 text-indigo-700 dark:bg-slate-700 dark:text-indigo-300' if active=='/resumes' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-file-lines"></i>Résumés</a>
         <a href="/chat" class="flex items-center gap-2 px-3 py-1 rounded-full transition-colors {{ 'bg-indigo-100 text-indigo-700 dark:bg-slate-700 dark:text-indigo-300' if active=='/chat' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-comments"></i>Chat</a>
+        <a href="/match" class="flex items-center gap-2 px-3 py-1 rounded-full transition-colors {{ 'bg-indigo-100 text-indigo-700 dark:bg-slate-700 dark:text-indigo-300' if active=='/match' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-star"></i>Match</a>
         <a href="/projects" class="flex items-center gap-2 px-3 py-1 rounded-full transition-colors {{ 'bg-indigo-100 text-indigo-700 dark:bg-slate-700 dark:text-indigo-300' if active=='/projects' else 'hover:bg-indigo-50 dark:hover:bg-slate-700' }}"><i class="fa-solid fa-table-list"></i>Projects</a>
       </div>
       <div class="mt-4 pt-4 border-t space-y-2">

--- a/templates_en/match_form.html
+++ b/templates_en/match_form.html
@@ -1,0 +1,49 @@
+{% extends "_base.html" %}
+{% set active = "/match" %}
+{% set page_title = "Match" %}
+
+{% block body %}
+<div class="max-w-4xl mx-auto space-y-6">
+  <form id="match-form" class="card space-y-4">
+    <div>
+      <label class="block font-medium mb-1">Description</label>
+      <textarea name="description" rows="6" class="w-full border rounded px-3 py-2"></textarea>
+    </div>
+    <div>
+      <label class="block font-medium mb-1">File (optional)</label>
+      <input type="file" name="file" accept=".pdf,.docx" class="w-full">
+    </div>
+    <div>
+      <label class="block font-medium mb-1">Priority skills</label>
+      <input type="text" name="priority_skills" class="w-full border rounded px-3 py-2">
+    </div>
+    <div>
+      <span class="block font-medium mb-1">Candidates</span>
+      <div class="space-y-1">
+        {% for c in candidates %}
+        <label class="flex items-center gap-2">
+          <input type="checkbox" name="candidate_ids" value="{{ c.id }}" class="candidate-box">
+          <span>{{ c.name }}</span>
+        </label>
+        {% endfor %}
+      </div>
+    </div>
+    <button type="submit" class="px-4 py-2 rounded bg-indigo-600 text-white">Match</button>
+  </form>
+  <div id="results"></div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.getElementById('match-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const form = e.target;
+  const fd = new FormData(form);
+  const results = document.getElementById('results');
+  results.innerHTML = '...';
+  const resp = await fetch('/match_project', {method: 'POST', body: fd});
+  results.innerHTML = await resp.text();
+});
+</script>
+{% endblock %}

--- a/tests/test_match_page.py
+++ b/tests/test_match_page.py
@@ -1,0 +1,29 @@
+import types
+import pytest
+from fastapi.responses import HTMLResponse
+import main
+
+class DummyRequest:
+    def __init__(self, path="/match"):
+        self.url = types.SimpleNamespace(path=path)
+        self.cookies = {}
+
+@pytest.mark.asyncio
+async def test_match_requires_auth():
+    with pytest.raises(main.HTTPException) as exc:
+        await main.match_form(DummyRequest())
+    assert exc.value.status_code == 302
+
+@pytest.mark.asyncio
+async def test_match_returns_form(monkeypatch):
+    async def _require_login():
+        return {"username": "u"}
+    async def _get_current_user(*a, **k):
+        return {"username": "u"}
+    monkeypatch.setattr(main, "require_login", _require_login)
+    monkeypatch.setattr(main, "get_current_user", _get_current_user)
+    async def fake_render(*a, **kw):
+        return HTMLResponse("OK")
+    monkeypatch.setattr(main, "render", fake_render)
+    resp = await main.match_form(DummyRequest())
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add `/match` route to serve match form
- create `match_form.html` templates
- link match page in navigation
- test route permissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a7d39d708330b077ec0084ece92f